### PR TITLE
#US-1128: Minor improvements and fixes

### DIFF
--- a/assets/add/@web-root/sites/default/local.settings.php.twig
+++ b/assets/add/@web-root/sites/default/local.settings.php.twig
@@ -94,7 +94,7 @@ $settings['config_exclude_modules'] = ['devel', 'devel_entity_updates', 'iq_stag
 $settings['trusted_host_patterns'] = [
   '^.+\.localdev\.iqual.ch$',
   '^.+\.iqual\.pagekite\.me$',
-  '^.+\.githubpreview.dev$',
+  '^.+\.github\.dev$',
   '^localhost$',
 ];
 

--- a/assets/merge/.env.twig
+++ b/assets/merge/.env.twig
@@ -1,5 +1,5 @@
 # docker-compose's project name.
-COMPOSE_PROJECT_NAME={{ name }}-sw-project
+COMPOSE_PROJECT_NAME={{ project_name|default(name ~ '-sw-project') }}
 
 # This should the codified project's name, e.g. wks, ezs, sqs, tg and so on.
 PROJECT_CODE_NAME={{ name }}

--- a/assets/merge/.gitignore.twig
+++ b/assets/merge/.gitignore.twig
@@ -66,7 +66,8 @@ db.session.sql
 
 # Custom themes and modules
 !app/public/themes/custom/iq_custom
-!app/public/modules/custom/{{ name }}
+!app/public/modules/custom/{{ name|replace({'-': '_'}) }}
+!app/public/modules/custom/{{ name|replace({'-': '_'}) }}_*
 
 # Assets
 app/resources/*.sql

--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -133,7 +133,7 @@ new: check-in-container-true ## Create new Drupal site from repo
 	fi
 	if compgen -G "$$APP_ROOT/resources/*.sql.gz" > /dev/null; then
 		drush sqlq --file=$$(compgen -G "$$APP_ROOT/resources/*.sql.gz" | head -1)
-		drush deploy || exit 1
+		drush updb || exit 1
 	else
 		drush si $(DRUSH_FLAGS) || exit 1
 	fi

--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -157,7 +157,6 @@ install: check-in-container-true ## Install existing Drupal site
 	fi
 	echo "Deploying Drupal"
 	drush deploy || exit 1
-	make theme
 	chown -Rf www-data:www-data .
 
 uninstall: check-in-container-true ## Uninstall/reset Drupal site

--- a/assets/replace/manifests/local/docker-compose.yml.twig
+++ b/assets/replace/manifests/local/docker-compose.yml.twig
@@ -11,6 +11,9 @@ x-drupal-variables: &drupal-variables
   SW_PROJECT_ROOT: /project
   APP_ROOT: /project/app
   NGINX_ROOT: /project/app/public
+{% if runtime.php_memory_limit %}
+  PHP_MEMORY_LIMIT: {{ runtime.php_memory_limit }}
+{% endif %}
 
 services:
   db:

--- a/assets/replace/manifests/local/docker-compose.yml.twig
+++ b/assets/replace/manifests/local/docker-compose.yml.twig
@@ -7,7 +7,7 @@ x-drupal-variables: &drupal-variables
   MYSQL_DATABASE_PW: drupal
   DRUPAL_ENVIRONMENT: local
   DRUSH_OPTIONS_URI: {{ name }}-sw-project.{{ local_domain_suffix }}
-  VIRTUAL_HOST: {{ name }}-sw-project.{{ local_domain_suffix }}
+  VIRTUAL_HOST: "*.{{ name }}-sw-project.{{ local_domain_suffix }},{{ name }}-sw-project.{{ local_domain_suffix }}"
   SW_PROJECT_ROOT: /project
   APP_ROOT: /project/app
   NGINX_ROOT: /project/app/public

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
                 "db_image": "iqualch/dc-mysql",
                 "db_image_tag": "vVERSION",
                 "php_version": 7.3,
-                "db_version": 10.3,
-                "php_memory_limit": "128M"
+                "db_version": 10.3
             },
             "workflows": {
                 "update": true,

--- a/questions.json
+++ b/questions.json
@@ -11,7 +11,7 @@
             "question": "What is the <info>code name</info> of the project?",
             "default": "[root-package-name]",
             "filter": "/iqual\\/(.+?)-sw-project/$1/",
-            "validation": "[a-z][a-z0-9\\-]{0,28}[a-z0-9]"
+            "validation": "[a-z][a-z0-9\\-]{0,18}[a-z0-9]"
         },
         "title": {
             "question": "What is the <info>title</info> of the project?",

--- a/questions.json
+++ b/questions.json
@@ -36,7 +36,7 @@
         },
         "drupal_spot": {
             "question": "Where is the current Single Point of Truth (<info>SPOT</info>) of the Drupal database?",
-            "default": "dev",
+            "default": "stage",
             "options": [
                 "dev",
                 "stage",


### PR DESCRIPTION
## Tasks
Small improvements and fixes to the current IDP:

- [x] Fix the trusted host patterns for the new GitHub Codespaces domains. Will need a migration since it’s located in the `local.settings.php` file.
- [x] Add support for multi-domain module, by adding wildcard to `docker-compose.yml` virtual hosts.
- [x] Remove `make theme` from `make install` since compilation has been integrated into a `drush deploy` hook.
- [x] Change `drush deploy` in `make new` to `updb` to fix new installations from a db asset.
- [x] Add override for non-standard project names (e.g. `example` vs. `example-inc-sw-project`)
- [x] Improve custom module `.gitignore` (i.e. add `CODE_NAME_*` and make sure `-` are replace with `_`)
- [x] Add proper support for setting PHP memory limit
- [x] Reduce the allowed length of the name string
- [x] Change the default SPOT to `stage`

## Notes

* The change to the virtual hosts generation will deprecate the usage of different local domains as opposed to subdomains (e.g. `test.example-sw-project.localdev.iqual.ch` vs. `test.localdev.iqual.ch`).