### PR TITLE
Fix project name override

### DIFF
--- a/assets/replace/.vscode/settings.json.twig
+++ b/assets/replace/.vscode/settings.json.twig
@@ -1,5 +1,5 @@
 {
-  "window.title": "{{ name }}-sw-project${separator}${dirty}${activeEditorMedium}${separator}${appName}",
+  "window.title": "{{ project_name|default(name ~ '-sw-project') }}${separator}${dirty}${activeEditorMedium}${separator}${appName}",
   "terminal.integrated.profiles.linux": {
     "bash": {
       "path": "/bin/bash",

--- a/assets/replace/README.md.twig
+++ b/assets/replace/README.md.twig
@@ -7,7 +7,7 @@
 This repository contains the software project for the {{ title|default(name) }} Drupal website. It contains a Drupal installation with custom business logic, configuration, themes and styling for the website.
 
 * [Live URL]({{ url }}/)
-* [Local URL](https://{{ name }}-sw-project.{{ local_domain_suffix }}/)
+* [Local URL](https://{{ project_name|default(name ~ '-sw-project') }}.{{ local_domain_suffix }}/)
 
 ## Usage
 

--- a/assets/replace/manifests/local/docker-compose.yml.twig
+++ b/assets/replace/manifests/local/docker-compose.yml.twig
@@ -6,8 +6,8 @@ x-drupal-variables: &drupal-variables
   MYSQL_DATABASE_USER: drupal
   MYSQL_DATABASE_PW: drupal
   DRUPAL_ENVIRONMENT: local
-  DRUSH_OPTIONS_URI: {{ name }}-sw-project.{{ local_domain_suffix }}
-  VIRTUAL_HOST: "*.{{ name }}-sw-project.{{ local_domain_suffix }},{{ name }}-sw-project.{{ local_domain_suffix }}"
+  DRUSH_OPTIONS_URI: {{ project_name|default(name ~ '-sw-project') }}.{{ local_domain_suffix }}
+  VIRTUAL_HOST: "*.{{ project_name|default(name ~ '-sw-project') }}.{{ local_domain_suffix }},{{ project_name|default(name ~ '-sw-project') }}.{{ local_domain_suffix }}"
   SW_PROJECT_ROOT: /project
   APP_ROOT: /project/app
   NGINX_ROOT: /project/app/public


### PR DESCRIPTION
If the code name (`name` variable) does not adhere to the default project naming scheme (`CODE_NAME-sw-project`) then it can be overridden with the `project_name` variable. However this is not yet the case in every asset template (e.g. `VIRTUAL_HOST` in `docker-compose.yml` file).

## Tasks

- [x] Fix project name override

## Notes

* The goal is to deprecate this feature eventually. Projects should always be adhering to the naming scheme.