### PR TITLE
Add version constraint to `project-scaffold`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "iqual/project-scaffold": "*"
+        "iqual/project-scaffold": "^1.0"
     },
     "extra": {
         "project-scaffold": {


### PR DESCRIPTION
Currently the asset package supports any version of the `project-scaffold` composer plugin. It should only support the stable version `^1.0`.

## Tasks

- [x] Add version constraint `^1.0` to `project-scaffold` composer plugin.