### PR TITLE
Fix drush root for remote commands

### DIFF
--- a/assets/replace/@app-root/drush/sites/self.site.yml.twig
+++ b/assets/replace/@app-root/drush/sites/self.site.yml.twig
@@ -2,19 +2,19 @@
 # Docs at https://github.com/drush-ops/drush/blob/master/examples/example.site.yml
 
 dev:
-  root: ${env.APP_ROOT}
+  root: ${env.NGINX_ROOT}
   user: ${env-name}-drpl-${env.PROJECT_CODE_NAME}_${env.K8S_DEV_CONTEXT}
   host: ${env.SSH_HOST}
   uri: https://${env.PROJECT_CODE_NAME}-drpl.docker-${env-name}.iqual.ch
 
 stage:
-  root: ${env.APP_ROOT}
+  root: ${env.NGINX_ROOT}
   user: ${env-name}-drpl-${env.PROJECT_CODE_NAME}_${env.K8S_STAGE_CONTEXT}
   host: ${env.SSH_HOST}
   uri: https://${env.PROJECT_CODE_NAME}-drpl.docker-${env-name}.iqual.ch
 
 prod:
-  root: ${env.APP_ROOT}
+  root: ${env.NGINX_ROOT}
   user: ${env-name}-drpl-${env.PROJECT_CODE_NAME}_${env.K8S_PROD_CONTEXT}
   host: ${env.SSH_HOST}
   uri: {{ url }}


### PR DESCRIPTION
## Tasks

- [x] Fix the drush root in the `sef.sites.yml` file to point to the `NGINX_ROOT` instead of the `APP_ROOT`.

## Notes

* This fixes support for `drush rsync` commands.
* When ssh-ing into projects using drush the working directory will be the `NGINX_ROOT` too.