### PR TITLE
Improv prompt in `delete-local` target

### DIFF
--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -116,7 +116,7 @@ deploy-%-kubectl: check-in-container-false
 
 delete-local: check-in-container-false
 	@echo -e " $(MSG_WARNING) This will irreversible delete your local database's and container's data. This will not affect code in the repo."
-	echo -n "Do you want to continue (y)? " && read REPLY && [[ $$REPLY == "y" ]] || exit 1
+	echo -n "Do you want to continue? [n] " && read REPLY && [[ $$REPLY == "y" ]] || exit 1
 	docker-compose -p $(COMPOSE_PROJECT_NAME) -f ./manifests/local/docker-compose.yml down -v --remove-orphans || exit 1
 	docker volume rm $(COMPOSE_PROJECT_NAME)_{db,web}_storage 2>/dev/null || true
 


### PR DESCRIPTION
## Tasks

- [x] Fix the prompt in the `delete-local` target to correctly show the default of `n` instead of `y`.