### PR TITLE
#US-1242: Add Kubernetes remote workload patching

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ assets/replace/
 ├── Makefile
 ├── README.md.twig
 └── manifests
+    ├── dev
+    │   └── patch.yml.twig
+    ├── stage
+    │   └── patch.yml.twig
+    ├── prod
+    │   └── patch.yml.twig
     └── local
         └── docker-compose.yml.twig
 ```

--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -100,6 +100,8 @@ deploy-%: check-in-container-false ## Deploy environment %
 		make deploy-$*-compose
 	elif [[ -f ./manifests/$*/deployment.yml ]]; then
 		make deploy-$*-kubectl
+	elif [[ -f ./manifests/$*/patch.yml ]]; then
+		make deploy-$*-kubectl-patch
 	elif [[ -f ./manifests/$*/kustomization.yml ]]; then
 		make deploy-$*-kustomize
 	else
@@ -112,11 +114,19 @@ deploy-%-compose: check-in-container-false env-local
 	docker-compose -p $(COMPOSE_PROJECT_NAME) -f ./manifests/$*/docker-compose.yml up $(COMPOSE_FLAGS)
 
 deploy-%-kubectl: check-in-container-false
-	@echo "Deploying $* docker-compose manifests"
+	@echo "Deploying $* kubernetes manifests"
 	K8S_CONTEXT="$(K8S_$(shell echo $* | tr a-z A-Z)_CONTEXT)"
 	K8S_NAMESPACE="$*-drpl-$(PROJECT_CODE_NAME)"
 	kubectl create namespace $$K8S_NAMESPACE --dry-run=client -o yaml | kubectl apply --context $$K8S_CONTEXT -f -
 	kubectl apply --context $$K8S_CONTEXT -f ./manifests/$*/ -n $$K8S_NAMESPACE
+
+deploy-%-kubectl-patch: check-in-container-false
+	@echo "Patching $* kubernetes manifests"
+	K8S_CONTEXT="$(K8S_$(shell echo $* | tr a-z A-Z)_CONTEXT)"
+	K8S_NAMESPACE="$*-drpl-$(PROJECT_CODE_NAME)"
+	K8S_DEPLOYMENT="$(PROJECT_CODE_NAME)-drpl"
+	kubectl patch --context $$K8S_CONTEXT deployment $$K8S_DEPLOYMENT -p "$$(cat ./manifests/$*/patch.yml)" -n $$K8S_NAMESPACE || exit 1
+	kubectl rollout status --context $$K8S_CONTEXT -w deployment $$K8S_DEPLOYMENT -n $$K8S_NAMESPACE
 
 delete-local: check-in-container-false
 	@echo -e " $(MSG_WARNING) This will irreversible delete your local database's and container's data. This will not affect code in the repo."

--- a/assets/replace/manifests/dev/patch.yml.twig
+++ b/assets/replace/manifests/dev/patch.yml.twig
@@ -1,0 +1,13 @@
+spec:
+  template:
+    spec:
+      containers:
+      - name: {{ name}}-drpl
+        image: {{ runtime.base_image }}:{{ runtime.base_image_tag|replace({'VERSION': runtime.php_version}) }}
+        env:
+        - name: DRUPAL_ENVIRONMENT
+          value: dev
+{% if runtime.php_memory_limit %}
+        - name: PHP_MEMORY_LIMIT
+          value: {{ runtime.php_memory_limit }}
+{% endif %}

--- a/assets/replace/manifests/dev/patch.yml.twig
+++ b/assets/replace/manifests/dev/patch.yml.twig
@@ -3,7 +3,7 @@ spec:
     spec:
       containers:
       - name: {{ name}}-drpl
-        image: {{ runtime.base_image }}:{{ runtime.base_image_tag|replace({'VERSION': runtime.php_version}) }}
+        image: {{ runtime.base_image }}:{{ runtime.base_image_tag|replace({'VERSION': runtime.php_version, '-dev': ''}) }}
         env:
         - name: DRUPAL_ENVIRONMENT
           value: dev

--- a/assets/replace/manifests/prod/patch.yml.twig
+++ b/assets/replace/manifests/prod/patch.yml.twig
@@ -1,0 +1,13 @@
+spec:
+  template:
+    spec:
+      containers:
+      - name: {{ name}}-drpl
+        image: {{ runtime.base_image }}:{{ runtime.base_image_tag|replace({'VERSION': runtime.php_version}) }}
+        env:
+        - name: DRUPAL_ENVIRONMENT
+          value: prod
+{% if runtime.php_memory_limit %}
+        - name: PHP_MEMORY_LIMIT
+          value: {{ runtime.php_memory_limit }}
+{% endif %}

--- a/assets/replace/manifests/prod/patch.yml.twig
+++ b/assets/replace/manifests/prod/patch.yml.twig
@@ -3,7 +3,7 @@ spec:
     spec:
       containers:
       - name: {{ name}}-drpl
-        image: {{ runtime.base_image }}:{{ runtime.base_image_tag|replace({'VERSION': runtime.php_version}) }}
+        image: {{ runtime.base_image }}:{{ runtime.base_image_tag|replace({'VERSION': runtime.php_version, '-dev': ''}) }}
         env:
         - name: DRUPAL_ENVIRONMENT
           value: prod

--- a/assets/replace/manifests/stage/patch.yml.twig
+++ b/assets/replace/manifests/stage/patch.yml.twig
@@ -3,7 +3,7 @@ spec:
     spec:
       containers:
       - name: {{ name}}-drpl
-        image: {{ runtime.base_image }}:{{ runtime.base_image_tag|replace({'VERSION': runtime.php_version}) }}
+        image: {{ runtime.base_image }}:{{ runtime.base_image_tag|replace({'VERSION': runtime.php_version, '-dev': ''}) }}
         env:
         - name: DRUPAL_ENVIRONMENT
           value: stage

--- a/assets/replace/manifests/stage/patch.yml.twig
+++ b/assets/replace/manifests/stage/patch.yml.twig
@@ -1,0 +1,13 @@
+spec:
+  template:
+    spec:
+      containers:
+      - name: {{ name}}-drpl
+        image: {{ runtime.base_image }}:{{ runtime.base_image_tag|replace({'VERSION': runtime.php_version}) }}
+        env:
+        - name: DRUPAL_ENVIRONMENT
+          value: stage
+{% if runtime.php_memory_limit %}
+        - name: PHP_MEMORY_LIMIT
+          value: {{ runtime.php_memory_limit }}
+{% endif %}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -46,7 +46,9 @@ The following `make` targets are available in the project's `Makefile`. They can
 
 * `local`: Alias for `deploy-local`
 * `deploy-local`: Deploy the local environment (`docker-compose`)
-* `deploy-prod`: Deploy the production environment (Kubernetes) – _not yet supported_
+* `deploy-dev`: Deploy the development environment (Kubernetes) – _patch operation by default_
+* `deploy-stage`: Deploy the staging environment (Kubernetes) – _patch operation by default_
+* `deploy-prod`: Deploy the production environment (Kubernetes) – _patch operation by default_
 * `deploy-%`: Deploy the `%` environment (replace `%` with name of environment in `./manifests` folder)
 * `delete-local`: Delete the local deployment with `docker-compose` permanently
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -26,6 +26,12 @@ To deploy the local environment run `make deploy-local`. The command will look f
 
 The remote deployment into a Kubernetes cluster is currently done using Rancher/Helm. See the [prod deployment](https://support-iqual.atlassian.net/wiki/spaces/ID/pages/1864073238/Prod-Instance+Rancher) and [dev/staging deployment guide](https://support-iqual.atlassian.net/wiki/spaces/ID/pages/1863942165/Dev-Instance+Staging+Rancher) for more details.
 
+### Patching existing deployments
+
+A patch to an existing deployment can be applied using the `make deploy-%` targets (e.g. `make deploy-prod` for a production patch). The patch includes the currently set image and environment variables (`DRUPAL_ENVIRONMENT` and optionally `PHP_MEMORY_LIMIT`).
+
+> The command will re-deploy existing pods and wait for a successful roll-out.
+
 ### Non-default Kubernetes contexts
 
 If a project is being deployed into a non-default cluster context, then the context variable has to be overriden. The default contexts can be found in the `kubernetes_contexts` variables in the [`composer.json`](../composer.json).

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -53,6 +53,9 @@ The `manifests` directory contains all the definitions for a deployment of a env
 .
 ├── ...
 └── manifests
+    ├── dev                     # Remote development deployment patch (Kubernetes)
+    ├── stage                   # Remote staging deployment patch (Kubernetes)
+    ├── prod                    # Remote production deployment patch (Kubernetes)
     └── local                   # Local deployment manifest (compose)
 ```
 


### PR DESCRIPTION
## Tasks

- [x] Add kubernetes manifests for patching remote workloads
  * The patch includes the currently set image and environment variables (`DRUPAL_ENVIRONMENT` and optionally `PHP_MEMORY_LIMIT`).
- [x] Add `make deploy-%` targets for deploying the patches
- [x] Add documentation on patching