### PR TITLE
#US-1145: Optimize XDebug integration

### DIFF
--- a/assets/replace/.vscode/launch.json
+++ b/assets/replace/.vscode/launch.json
@@ -11,7 +11,9 @@
       "port": 9003,
       "pathMappings": {
         "/project/": "${workspaceRoot}/",
-      }
+      },
+      "preLaunchTask": "enable-xdebug",
+      "postDebugTask": "disable-xdebug"
     }
   ]
 }

--- a/assets/replace/.vscode/launch.json
+++ b/assets/replace/.vscode/launch.json
@@ -12,8 +12,8 @@
       "pathMappings": {
         "/project/": "${workspaceRoot}/",
       },
-      "preLaunchTask": "enable-xdebug",
-      "postDebugTask": "disable-xdebug"
+      "preLaunchTask": "make xdebug",
+      "postDebugTask": "make xdebug-disable"
     }
   ]
 }

--- a/assets/replace/.vscode/tasks.json
+++ b/assets/replace/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+    "version": "2.0.0",
+    "tasks": [{
+        "label": "enable-xdebug",
+        "command": "make xdebug &",
+        "type": "shell",
+        "presentation": {
+            "reveal": "silent"
+        }
+    },
+    {
+        "label": "disable-xdebug",
+        "command": "make xdebug-disable",
+        "type": "shell",
+        "presentation": {
+            "reveal": "silent"
+        }
+    }]
+}

--- a/assets/replace/.vscode/tasks.json
+++ b/assets/replace/.vscode/tasks.json
@@ -1,19 +1,41 @@
 {
     "version": "2.0.0",
     "tasks": [{
-        "label": "enable-xdebug",
-        "command": "make xdebug &",
+        "label": "make xdebug",
+        "command": "make xdebug",
+        "isBackground": true,
         "type": "shell",
         "presentation": {
-            "reveal": "silent"
-        }
+            "reveal": "silent",
+            "revealProblems": "onProblem",
+            "close": true
+        },
+        "problemMatcher": [
+            {
+              "pattern": [
+                {
+                  "regexp": ".",
+                  "file": 1,
+                  "location": 2,
+                  "message": 3
+                }
+              ],
+              "background": {
+                "activeOnStart": true,
+                "beginsPattern": ".",
+                "endsPattern": ".",
+              }
+            }
+        ]
     },
     {
-        "label": "disable-xdebug",
+        "label": "make xdebug-disable",
         "command": "make xdebug-disable",
         "type": "shell",
         "presentation": {
-            "reveal": "silent"
+            "reveal": "silent",
+            "revealProblems": "onProblem",
+            "close": true
         }
     }]
 }

--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -124,6 +124,17 @@ delete-local: check-in-container-false
 	docker-compose -p $(COMPOSE_PROJECT_NAME) -f ./manifests/local/docker-compose.yml down -v --remove-orphans || exit 1
 	docker volume rm $(COMPOSE_PROJECT_NAME)_{db,web}_storage 2>/dev/null || true
 
+# PHP commands
+xdebug: check-in-container-true ## Enable XDebug
+	@if [[ "$(DRUPAL_ENVIRONMENT)" == "local" ]]; then
+		sudo -E enable_xdebug
+	fi
+
+xdebug-disable: check-in-container-true ## Disable XDebug
+	@if [[ "$(DRUPAL_ENVIRONMENT)" == "local" ]]; then
+		sudo -E disable_xdebug
+	fi
+
 # Drupal (Drush) commands
 new: check-in-container-true ## Create new Drupal site from repo
 	@echo "Creating new Drupal site"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -50,6 +50,13 @@ The following `make` targets are available in the project's `Makefile`. They can
 * `deploy-%`: Deploy the `%` environment (replace `%` with name of environment in `./manifests` folder)
 * `delete-local`: Delete the local deployment with `docker-compose` permanently
 
+### PHP commands
+
+> These commands can only be run from within the Drupal container
+
+* `xdebug`: Enable XDebug and restart the web server.
+* `xdebug-disable`: Disable XDebug and restart the web server.
+
 ## Scripts and aliases
 
 There are also scripts and a bunch of aliases available in the Drupal container. Check the [script documentation of the Drupal image](https://github.com/iqual-ch/dc-drupal/blob/main/docs/scripts.md).

--- a/docs/drupal-development.md
+++ b/docs/drupal-development.md
@@ -62,15 +62,21 @@ In order for GitHub Codespaces to work a few environment variables are needed fo
 
 ## XDebug
 
-XDebug is enabled by default in the image for debugging PHP (`debug` mode). The VS Code setup includes the XDebug debugger for adding break-points. It will try to start debugging on any request and no further tools are required (like browser extensions). This has a performance impact so it is also possible to disable XDebug altogether.
+XDebug is disabled by default in the image for debugging PHP (`trigger` mode). The VS Code setup includes the XDebug debugger for adding break-points. It will automatically enable XDebug once a debugging session is launched (i.e. when pressing F5) by running the `xdebug` `make` target as a background task.
 
 Check the [official XDebug documentation](https://xdebug.org/docs/) for further more advanced documentation.
 
 Below are some common configurations for XDebug. To add a environment variable it can be added as a separate line in `.env.secrets`. Whenever a environment variable is changed the deployment has to re-deployed. In the case of VS Code this can be simply done by doing a `Rebuild Container`.
 
-### Disabling XDebug
+### Enabling and Disabling XDebug
 
-It is possible to disable XDebug altogether by setting the environment variable `XDEBUG_MODE` to `off`.
+VS Code will automatically enable XDebug when a debugging session is started. However XDebug can also be manually enabled by running the `make xdebug` target. For disabling there is a `make xdebug-disable` target.
+
+```bash
+make xdebug
+```
+
+To completely disable XDebug it can also be turned off by setting the following environment variable:
 
 ```bash
 XDEBUG_MODE=off
@@ -85,9 +91,9 @@ XDEBUG_MODE=profile
 XDEBUG_CONFIG="output_dir=/project"
 ```
 
-> Currently the profiler is started on every request (including cli commands) even when `start_with_request=trigger` is set. This is a bug.
+The profiler can then be triggered by either enabling xdebug with `make xdebug` or by using the trigger variable `XDEBUG_TRIGGER` (in `ENV`, `GET` or `COOKIE`). For example to profile a drush command `XDEBUG_TRIGGER= drush status` can be run.
 
-To analyze the generated `cachegrind` files there are a few available tools. Check the [profiling documentation on the official XDebug page](https://xdebug.org/docs/profiler). For a very simple overview it is possible to use Webgrind to display a weighted table or graph of the called function.
+To analyze the generated `cachegrind` files there are a few available tools. Check the [profiling documentation on the official XDebug page](https://xdebug.org/docs/profiler). For a very simple overview it is possible to use [Webgrind](https://github.com/jokkedk/webgrind) to display a weighted table or graph of the called function.
 
 > Make sure to not commit the cachegrind files.
 


### PR DESCRIPTION
## Tasks

- [x] Optimize XDebug so it is disabled by default and only enabled when launching a debugging session in VS Code (F5).
- [x] Add `make xdebug` target for manually start-/stopping XDebug.
- [x] Update documentation

## Notes

* XDebug is set to `trigger` by default
* The Drupal image has a new `enable_xdebug` and `disable_xdebug` script.
* This PR thus adds support for just in time debugging:
  * Adds a new `xdebug` and `xdebug-disable` make target
  * Adds an enable & disable xdebug task in `tasks.json` calling `make`.
  * Adds a `preLaunchTask` and `postDebugTask` to the XDebug VS Code extension

This way XDebug gets “all the way” enabled when pressing F5 in VS Code and will also be disabled afterwards. By default XDebug will still be in `trigger` mode as a fallback.
