### PR TITLE
#US-1135: Add upgrade workflow for Drupal

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ assets/add/
 Assets that are fully managed by the package and will be created if inexistant or otherwise overwritten in the target destination:
 
 <details>
-<summary>Show structure of repplaced assets</summary>
+<summary>Show structure of replaced assets</summary>
 <br>
 
 ```
@@ -66,10 +66,14 @@ assets/replace/
 │   └── devcontainer.json
 ├── .github
 │   ├── actions
-│   │   └── install-local
-│   │       └── action.yml.twig
+│   │   ├── install-local
+│   │   │   └── action.yml.twig
+│   │   └── upgrade
+│   │       ├── rector.php
+│   │       └── upgrade.sh
 │   └── workflows
 │       ├── update.yml.twig
+│       ├── upgrade.yml.twig
 │       └── visual-regression-testing.yml.twig
 ├── .vscode
 │   ├── launch.json

--- a/assets/replace/.github/actions/upgrade/rector.php
+++ b/assets/replace/.github/actions/upgrade/rector.php
@@ -1,0 +1,41 @@
+<?php
+
+// @codingStandardsIgnoreFile
+
+declare(strict_types=1);
+
+use DrupalFinder\DrupalFinder;
+use DrupalRector\Set\Drupal9SetList;
+use Rector\Config\RectorConfig;
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Set\ValueObject\LevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    // Set desired version support
+    $rectorConfig->sets([
+        Drupal9SetList::DRUPAL_9,
+        LevelSetList::UP_TO_PHP_81,
+    ]);
+
+    // Add backwards compatibility
+    $rectorConfig->phpVersion(PhpVersion::PHP_73);
+
+    $parameters = $rectorConfig->parameters();
+
+    $drupalFinder = new DrupalFinder();
+    $drupalFinder->locateRoot(__DIR__);
+    $drupalRoot = $drupalFinder->getDrupalRoot();
+    $rectorConfig->autoloadPaths([
+        $drupalRoot . '/core',
+        $drupalRoot . '/modules',
+        $drupalRoot . '/profiles',
+        $drupalRoot . '/themes'
+    ]);
+
+    $rectorConfig->skip(['*/upgrade_status/tests/modules/*']);
+    $rectorConfig->fileExtensions(['php', 'module', 'theme', 'install', 'profile', 'inc', 'engine']);
+    $rectorConfig->importNames(true, false);
+    $rectorConfig->importShortClasses(false);
+    $parameters->set('drupal_rector_notices_as_comments', true);
+};

--- a/assets/replace/.github/actions/upgrade/upgrade.sh
+++ b/assets/replace/.github/actions/upgrade/upgrade.sh
@@ -147,7 +147,7 @@ for operation in "${OPERATIONS[@]}"; do
       fi
       if [ -z "$DATA" ]; then
         echo "No path defined. Auto-generating themes and module custom path."
-        DATA="$(git ls-tree -d -r $(git write-tree) --name-only | grep -E '(themes|modules)/custom/[^/]+$' | paste -s -d, -)"
+        DATA="$(git ls-tree -d -r $(git write-tree) --name-only | grep -E '(themes|modules)/custom/[^/]+$' | paste -s -)"
       fi
       rsh rector process ${DATA} ${OPTIONS} --config ${RECTOR_CONFIG}
       if [ -n "$RECTOR_INSTALLED" ]; then
@@ -158,7 +158,7 @@ for operation in "${OPERATIONS[@]}"; do
       if grep -q "drupal/coder" $COMPOSER_JSON_FILE; then
         if [ -z "$DATA" ]; then
           echo "No path defined. Auto-generating themes and module custom path."
-          DATA="$(git ls-tree -d -r $(git write-tree) --name-only | grep -E '(themes|modules)/custom/[^/]+$' | paste -s -d, -)"
+          DATA="$(git ls-tree -d -r $(git write-tree) --name-only | grep -E '(themes|modules)/custom/[^/]+$' | paste -s -)"
         fi
         rsh phpcbf ${OPTIONS} ${DATA} || true
       else

--- a/assets/replace/.github/actions/upgrade/upgrade.sh
+++ b/assets/replace/.github/actions/upgrade/upgrade.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+
+# Drupal Upgrade script
+#
+# Requires a composer file in the APP_ROOT (default: ./app)
+# Also requires a JSON_INPUT as either env var, stdin or file
+#
+# Usage:
+#       ./upgrade.sh operation.json
+# Alt:
+#       cat operations.json | ./upgrade.sh
+#       echo '{"operations":[{"action":"config:export"}]}' | ./upgrade.sh
+
+set -eo pipefail
+
+JSON_INPUT=${JSON_INPUT}
+
+# Accept STDIN for pipe input.
+if [[ -p /dev/stdin && ! -t 0 ]]; then
+  JSON_STDIN=$(</dev/stdin)
+  if [[ -n "$JSON_STDIN" ]]; then
+    JSON_INPUT=${JSON_STDIN}
+  fi
+else
+  # Accept file as an argument.
+  if [[ -n "$1" && -f "$1" ]]; then
+    JSON_INPUT=$(<"$1")
+  fi
+fi
+
+if [[ -z "$JSON_INPUT" ]]; then
+  echo "No input given!"
+  echo "Usage: ./upgrade.sh operation.json"
+  echo "Or by piping: cat operations.json | ./upgrade.sh"
+  exit 1
+fi
+
+# Validate JSON input.
+if ! jq -e . >/dev/null 2>&1 <<<"$JSON_INPUT"; then
+  echo "Failed to parse JSON_INPUT. Aborting."
+  jq -e . >/dev/null <<<"$JSON_INPUT"
+  exit 1
+fi
+
+APP_ROOT=${APP_ROOT:-app}
+COMPOSER_JSON_FILE="${APP_ROOT}/composer.json"
+
+if [ ! -f "${COMPOSER_JSON_FILE}" ]; then
+  echo "composer.json file not found. Aborting."
+  exit 1
+fi
+
+if [[ -n "$RSH" && "$RSH" == "make-cli" ]]; then
+  echo "Using remote shell: make cli"
+fi
+
+function rsh {
+  echo "$@"
+  if [[ -n "$RSH" && "$RSH" == "make-cli" ]]; then
+    # Make sure the arguments' value is quoted in a format that can be reused as input.
+    COMMAND="${*@Q}" make cli
+  else
+    exec "$@"
+  fi
+}
+
+# Check if the the string is a key in the composer requirements.
+function match_exists {
+  MATCH_VALUE=$1
+  RESULT=$(jq -r ".require + .[\"require-dev\"] | select(.\"${MATCH_VALUE}\")" "${COMPOSER_JSON_FILE}")
+  [ -n "${RESULT}" ]
+}
+
+# Read operations into a bash array
+readarray -t OPERATIONS < <(echo "${JSON_INPUT}" | jq -c '.operations[]')
+
+# Run all the operations sequentially.
+for operation in "${OPERATIONS[@]}"; do
+  ACTION=$(echo "${operation}" | jq -r '.action')
+  MATCH=$(echo "${operation}" | jq -r '.match // ""')
+  MATCH_INVERSE=$(echo "${operation}" | jq -r '.matchInverse // ""')
+
+  echo -e "---------------------------------------------------"
+  echo -e "\tRunning action: ${ACTION}"
+  echo -e "---------------------------------------------------"
+
+  # Check if operation matches composer requirements.
+  if [ -n "${MATCH}" ] && ! match_exists "${MATCH}"; then
+    echo "Didn't match \"${MATCH}\". Skipping operation."
+    continue
+  fi
+
+  # Check if operation doesn't match composer requirements.
+  if [ -n "${MATCH_INVERSE}" ] && match_exists "${MATCH_INVERSE}"; then
+    echo "Matched \"${MATCH_INVERSE}\". Skipping operation."
+    continue
+  fi
+
+  OPTIONS=$(echo "${operation}" | jq -r '.options // ""')
+
+  # Parse data variable and convert arrays into whitespace separated list.
+  DATA_INPUT=$(echo "${operation}" | jq '.data')
+  if [[ -n "${DATA_INPUT}" ]] && [[ "${DATA_INPUT}" != "null" ]]; then
+    if echo "${DATA_INPUT}" | jq -e 'type=="array"' > /dev/null; then
+        DATA=$(echo "${DATA_INPUT}" | jq -r 'join(" ")')
+    else
+        DATA=$(echo "${DATA_INPUT}" | jq -r '.')
+    fi
+  else
+    DATA=
+  fi
+
+  KEY=$(echo "${operation}" | jq -r '.key')
+
+  # Switch to relevant action.
+  case "${ACTION}" in
+    "remove")
+      rsh composer remove ${OPTIONS} -n ${DATA} -d ${APP_ROOT}
+      ;;
+    "require")
+      rsh composer require ${OPTIONS} -n ${DATA} -d ${APP_ROOT}
+      ;;
+    "update")
+      rsh composer update ${OPTIONS} -n ${DATA} -d ${APP_ROOT}
+      ;;
+    "bump")
+      rsh composer bump ${PACKAGES} -n -d ${APP_ROOT}
+      ;;
+    "config")
+      if [[ "${KEY}" =~ "extra."* ]] || [[ "${KEY}" =~ "repositories."* ]]; then
+        DATA_JSON=$(echo "${operation}" | jq -c '.data')
+        rsh composer config ${KEY} ${OPTIONS} --json "${DATA_JSON}" -n -d ${APP_ROOT}
+      else
+        rsh composer config ${KEY} ${DATA} ${OPTIONS} -n -d ${APP_ROOT}
+      fi
+      ;;
+    "rector")
+      if ! grep -q "palantirnet/drupal-rector" $COMPOSER_JSON_FILE; then
+        echo "Rector is not present, installing it temporarily."
+        rsh composer require --dev palantirnet/drupal-rector -n -d ${APP_ROOT}
+        RECTOR_INSTALLED=true
+      fi
+      RECTOR_CONFIG="${APP_ROOT}/rector.php"
+      if [ ! -f "${RECTOR_CONFIG}" ]; then
+        echo "Rector configuration is not present, using default."
+        RECTOR_CONFIG=".github/actions/upgrade/rector.php"
+      fi
+      rsh rector process ${DATA} ${OPTIONS} --config ${RECTOR_CONFIG}
+      if [ -n "$RECTOR_INSTALLED" ]; then
+        rsh composer remove --dev palantirnet/drupal-rector -n -d ${APP_ROOT}
+      fi
+      ;;
+    "phpcbf")
+      if grep -q "drupal/coder" $COMPOSER_JSON_FILE; then
+        rsh phpcbf ${OPTIONS} ${DATA} || true
+      else
+        echo "Warning: missing \"drupal/coder\" package for code beautifying"
+      fi
+      ;;
+    "updatedb")
+      rsh drush updatedb ${OPTIONS} -y
+      ;;
+    "pm:enable")
+      rsh drush pm:enable ${OPTIONS} -y ${DATA}
+      ;;
+    "pm:uninstall")
+      rsh drush pm:uninstall ${OPTIONS} -y ${DATA}
+      ;;
+    "theme:enable")
+      rsh drush theme:enable ${OPTIONS} -y ${DATA}
+      ;;
+    "theme:uninstall")
+      rsh drush theme:uninstall ${OPTIONS} -y ${DATA}
+      ;;
+    "config:export")
+      rsh drush config:export -y ${OPTIONS}
+      ;;
+    "config:set")
+      # Requires at least drush v11
+      DATA_JSON=$(echo "${operation}" | jq -c '.data')
+      rsh drush config:set -y ${OPTIONS} --input-format=yaml "${KEY}" ? "${DATA_JSON}"
+      ;;
+    "project:scaffold")
+      rsh composer project:scaffold -n ${OPTIONS} -d ${APP_ROOT}
+      ;;
+    "drupal:scaffold")
+      rsh composer drupal:scaffold -n ${OPTIONS} -d ${APP_ROOT}
+      ;;
+    "patch-add")
+      if grep -q "szeidler/composer-patches-cli" $COMPOSER_JSON_FILE; then
+        rsh composer patch-add ${OPTIONS} -n ${DATA} -d ${APP_ROOT}
+      else
+        echo "Warning: missing \"szeidler/composer-patches-cli\" package for patch CLI."
+      fi
+      ;;
+    "patch-remove")
+      if grep -q "szeidler/composer-patches-cli" $COMPOSER_JSON_FILE; then
+        rsh composer patch-remove ${OPTIONS} -n ${DATA} -d ${APP_ROOT}
+      else
+        echo "Warning: missing \"szeidler/composer-patches-cli\" package for patch CLI."
+      fi
+      ;;
+    "commit")
+      echo "git add . && git commit ${OPTIONS} -m "${DATA}" || true"
+      git add . && git commit ${OPTIONS} -m "${DATA}" || true
+      ;;
+    "reboot")
+      echo "make deploy-local COMPOSE_FLAGS=-d"
+      make deploy-local COMPOSE_FLAGS=-d
+      ;;
+    *)
+      echo "Unsupported action: ${ACTION}"
+      ;;
+  esac
+
+done
+
+echo "Successfully finished upgrade operations."

--- a/assets/replace/.github/actions/upgrade/upgrade.sh
+++ b/assets/replace/.github/actions/upgrade/upgrade.sh
@@ -60,7 +60,7 @@ function rsh {
     # Make sure the arguments' value is quoted in a format that can be reused as input.
     COMMAND="${*@Q}" make cli
   else
-    eval "$@"
+    eval "${*@Q}"
   fi
 }
 

--- a/assets/replace/.github/actions/upgrade/upgrade.sh
+++ b/assets/replace/.github/actions/upgrade/upgrade.sh
@@ -60,7 +60,7 @@ function rsh {
     # Make sure the arguments' value is quoted in a format that can be reused as input.
     COMMAND="${*@Q}" make cli
   else
-    exec "$@"
+    eval "$@"
   fi
 }
 

--- a/assets/replace/.github/actions/upgrade/upgrade.sh
+++ b/assets/replace/.github/actions/upgrade/upgrade.sh
@@ -209,7 +209,7 @@ for operation in "${OPERATIONS[@]}"; do
       fi
       ;;
     "commit")
-      echo "git add . && git commit ${OPTIONS} -m "${DATA}" || true"
+      echo "git add . && git commit ${OPTIONS} -m \"${DATA}\" || true"
       git add . && git commit ${OPTIONS} -m "${DATA}" || true
       ;;
     "reboot")

--- a/assets/replace/.github/actions/upgrade/upgrade.sh
+++ b/assets/replace/.github/actions/upgrade/upgrade.sh
@@ -145,6 +145,10 @@ for operation in "${OPERATIONS[@]}"; do
         echo "Rector configuration is not present, using default."
         RECTOR_CONFIG=".github/actions/upgrade/rector.php"
       fi
+      if [ -z "$DATA" ]; then
+        echo "No path defined. Auto-generating themes and module custom path."
+        DATA="$(git ls-tree -d -r $(git write-tree) --name-only | grep -E '(themes|modules)/custom/[^/]+$' | paste -s -d, -)"
+      fi
       rsh rector process ${DATA} ${OPTIONS} --config ${RECTOR_CONFIG}
       if [ -n "$RECTOR_INSTALLED" ]; then
         rsh composer remove --dev palantirnet/drupal-rector -n -d ${APP_ROOT}
@@ -152,6 +156,10 @@ for operation in "${OPERATIONS[@]}"; do
       ;;
     "phpcbf")
       if grep -q "drupal/coder" $COMPOSER_JSON_FILE; then
+        if [ -z "$DATA" ]; then
+          echo "No path defined. Auto-generating themes and module custom path."
+          DATA="$(git ls-tree -d -r $(git write-tree) --name-only | grep -E '(themes|modules)/custom/[^/]+$' | paste -s -d, -)"
+        fi
         rsh phpcbf ${OPTIONS} ${DATA} || true
       else
         echo "Warning: missing \"drupal/coder\" package for code beautifying"

--- a/assets/replace/.github/workflows/upgrade.yml.twig
+++ b/assets/replace/.github/workflows/upgrade.yml.twig
@@ -100,6 +100,7 @@ jobs:
       shell: bash
       env:
         RSH: "make-cli"
+        COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
       run: |
         make upgrade
 

--- a/assets/replace/.github/workflows/upgrade.yml.twig
+++ b/assets/replace/.github/workflows/upgrade.yml.twig
@@ -98,6 +98,8 @@ jobs:
 
     - name: Run Drupal upgrades script
       shell: bash
+      env:
+        RSH: "make-cli"
       run: |
         make upgrade
 

--- a/assets/replace/.github/workflows/upgrade.yml.twig
+++ b/assets/replace/.github/workflows/upgrade.yml.twig
@@ -1,0 +1,132 @@
+{% if workflows.upgrade %}
+{%- verbatim -%}
+name: Upgrade Drupal Project
+
+env:
+  DOCKER_WEB_PORT: 80:80
+
+on:
+  workflow_dispatch:
+    inputs:
+      token:
+        required: false
+        type: string
+        description: 'If you want pull requests created by this action to trigger an on: push or on: pull_request workflow then you cannot use the default GITHUB_TOKEN and need a Personal Access Token. If you want to use the GITHUB_TOKEN, then leave this field blank.'
+      require:
+        required: false
+        type: string
+        description: "Composer require a module or list of modules."
+      remove:
+        required: false
+        type: string
+        description: "Composer remove a module or list of modules."
+      enable:
+        required: false
+        type: string
+        description: "Enable a module or list of modules with Drush."
+      uninstall:
+        required: false
+        type: string
+        description: "Uninstall a module or list of modules with Drush."
+      payload:
+        required: false
+        type: string
+        description: "JSON encoded operation payload for advanced usage. See documentation."
+
+jobs:
+  upgrade:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Generate Input
+      shell: bash
+      run: |
+        set -eo pipefail
+
+        if [[ -z '${{ github.event.inputs.payload }}' ]]; then
+          PAYLOAD_ARRAY=()
+          if [[ -n '${{ github.event.inputs.require }}' ]]; then
+            PAYLOAD_ARRAY+=("{\"action\": \"require\", \"data\": \"${{ github.event.inputs.require }}\"}")
+          fi
+          if [[ -n '${{ github.event.inputs.remove }}' ]]; then
+            PAYLOAD_ARRAY+=("{\"action\": \"remove\", \"data\": \"${{ github.event.inputs.remove }}\"}")
+          fi
+          if [[ -n '${{ github.event.inputs.enable }}' ]]; then
+            PAYLOAD_ARRAY+=("{\"action\": \"pm:enable\", \"data\": \"${{ github.event.inputs.enable }}\"}")
+            PAYLOAD_ARRAY+=("{\"action\": \"config:export\"}")
+          fi
+          if [[ -n '${{ github.event.inputs.uninstall }}' ]]; then
+            PAYLOAD_ARRAY+=("{\"action\": \"pm:uninstall\", \"data\": \"${{ github.event.inputs.uninstall }}\"}")
+            PAYLOAD_ARRAY+=("{\"action\": \"config:export\"}")
+          fi
+          JSON_INPUT=$(echo ${PAYLOAD_ARRAY[@]} | jq -s '{"operations": . }' | jq -cr)
+          echo "JSON_INPUT=$JSON_INPUT" >> $GITHUB_ENV
+        else
+          echo "JSON_INPUT=${{ github.event.inputs.payload }}" >> $GITHUB_ENV
+        fi
+
+    - name: Validate JSON Input
+      shell: bash
+      run: |
+        if ! jq -e . >/dev/null 2>&1 <<<"$JSON_INPUT"; then
+          echo "Failed to parse JSON_INPUT. Aborting."
+          jq -e . >/dev/null <<<"$JSON_INPUT"
+          exit 1
+        fi
+
+        JSON_BEAUTIFIED=$(jq -r '.' <<< "$JSON_INPUT")
+        echo "JSON_BEAUTIFIED<<EOF" >> $GITHUB_ENV
+        echo "$JSON_BEAUTIFIED" >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
+
+    - name: Setup Git
+      shell: bash
+      run: |
+        git config user.name "${{ github.actor }}"
+        git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+    - name: Install Drupal locally
+      uses: ./.github/actions/install-local
+      with:
+        dockerhub_container_registry_user: ${{ secrets.DOCKERHUB_CONTAINER_REGISTRY_USER }}
+        dockerhub_container_registry_password: ${{ secrets.DOCKERHUB_CONTAINER_REGISTRY_PASSWORD }}
+        ssh_key: ${{ secrets.SSH_KEY }}
+        composer_auth: ${{ secrets.COMPOSER_AUTH }}
+
+    - name: Run Drupal upgrades script
+      shell: bash
+      run: |
+        make upgrade
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v5
+      with:
+        token: ${{ github.event.inputs.token || secrets.GITHUB_TOKEN }}
+        commit-message: Upgraded Drupal site
+        title: Upgraded Drupal site (${{ env.EXECUTION_DATE }})
+        body: |
+          Automatically generated Drupal upgrade (${{ env.EXECUTION_DATE }}):
+
+          ## Tasks
+
+          - [x] Ran Drupal upgrade operations (see payload for details)
+          - [x] Website quality assurance after upgrade using visual regression tests
+          - [ ] Synchronize config from live website
+          - [ ] Deploy upgrade to live website
+
+          <details><summary>Upgrade JSON payload</summary>
+
+          ```json
+          ${{ env.JSON_BEAUTIFIED }}
+          ```
+
+          </details>
+
+          Check the logs in the [Github Actions workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more information about the upgrade.
+        branch: misc/upgrade-${{ env.EXECUTION_DATE }}
+        reviewers: ${{ github.actor }}
+{% endverbatim -%}
+{% endif %}

--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -65,8 +65,8 @@ cli-%: check-in-container-false ## Attach to environment %
 	@echo "Attaching to $* environment"
 	EXEC_COMMAND="bash"
 	EXEC_FLAG="-it"
-	if [[ -n "$(COMMAND)" ]]; then
-		EXEC_COMMAND="$(COMMAND)"
+	if [[ -n "$$COMMAND" ]]; then
+		EXEC_COMMAND="$$COMMAND"
 		EXEC_FLAG=
 	fi
 	if [[ $* == "local" ]]; then
@@ -174,6 +174,17 @@ update: check-in-container-true ## Update Drupal site
 	drush cr
 	drush updb $(DRUSH_FLAGS) || exit 1
 	drush cex $(DRUSH_FLAGS)
+
+upgrade: ## Upgrade Drupal site
+	@echo "Upgrading Drupal"
+	if [[ -z "$$JSON_INPUT" ]]; then
+		echo -e " $(MSG_ERROR) Missing upgrade operations JSON_INPUT."
+		exit 1
+	fi
+	if make check-in-container-false >/dev/null 2>&1; then
+		RSH="make-cli"
+	fi
+	bash ./.github/actions/upgrade/upgrade.sh
 
 theme: check-in-container-true ## Compile current Drupal theme
 	@echo "Compiling Drupal theme"

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
             },
             "workflows": {
                 "update": true,
+                "upgrade": true,
                 "vrt": true
             },
             "local_domain_suffix": "localdev.iqual.ch",

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -2,6 +2,10 @@
 
 There are multiple GitHub Action workflows for running common automation tasks.
 
+* [Update: Updating Drupal projects](#update-drupal-project)
+* [Upgrade: Upgrading Drupal projects with specific operations](#upgrade-drupal-project)
+* [Visual Regression Testing: Comparing reference website to local test deployment](#visual-regression-testing)
+
 ## Update Drupal Project
 
 * Workflow: `update.yml`
@@ -11,6 +15,173 @@ There are multiple GitHub Action workflows for running common automation tasks.
     * Token: GitHub Personal Access Token
 
 This workflow will install the project in a GitHub Actions runner environment and run the Drupal update process on it (`make update`). If successful it will create a pull request with the changes. If a token is provided then the pull request created by this workflow will trigger other workflows running on push or pull request triggers.
+
+## Upgrade Drupal Project
+
+* Workflow: `upgrade.yml`
+* Runs on:
+    * Manual dispatch
+* Inputs
+    * Token: GitHub Personal Access Token
+    * Require: Composer require a module or list of modules
+    * Remove: Composer remove a module or list of modules
+    * Enable: Enable a module or list of modules with Drush
+    * Uninstall: Uninstall a module or list of modules with Drush
+    * Payload: JSON encoded operation payload for advanced usage
+
+This workflow will install the project in a GitHub Actions runner environment and run the Drupal upgrade process on it (`make upgrade`) using either the provided `require`, `remove`, `enable` and `uninstall` inputs or the provided `payload` (`payload` always overrides other inputs). If successful it will create a pull request with the changes. If a token is provided then the pull request created by this workflow will trigger other workflows running on push or pull request triggers.
+
+<details><summary>Available actions</summary>
+
+* `remove`: Removing packages with `composer remove`.
+* `require`: Requiring new or upgrading existing packages with `composer require`.
+* `update`: Updating packages with existing version constraints with `composer update`.
+* `bump`: Bumping the version constraints in the requirements according to the installed versions with `composer bump`.
+* `config`: Changing the composer config with `composer config` (repositories, platform, or extra like project-scaffold).
+* `rector`: Drupal rector for running automated code fixes and upgrades with `rector` (for custom project modules).
+* `phpcbf`: PHP code beautifying with `phpcbf` for improving code quality (for custom project modules).
+* `updatedb`: Drupal database updates with `drush updatedb`.
+* `enable`: Enabling Drupal modules with `drush pm:enable`.
+* `uninstall`: Uninstalling/disabling Drupal modules with `drush pm:uninstall`.
+* `enable`: Enabling Drupal themes `drush theme:enable`.
+* `uninstall`: Uninstalling/disabling Drupal themes `drush theme:uninstall`.
+* `export`: Exporting the Drupal configuration `drush config:export`.
+* `set`: Setting Drupal configuration with`drush config:set` (e.g. site title).
+* `project:scaffold`: Scaffolding project assets with `composer project:scaffold`.
+* `drupal:scaffold`: Scaffolding drupal assets with `composer drupal:scaffold`.
+* `patch-add`: Adding patches to composer with `composer patch-add`.
+* `patch-remove`: Removing patches from composer with `composer patch-remove`.
+* `commit`: Committing changes between operation actions with `git commit`.
+* `reboot`: Rebooting/restarting the local deployment between operation actions (e.g. when changing images).
+
+</details>
+
+A JSON payload has to follow this structure:
+
+* `operations`: Operations Array (`array`)
+    * Operation object
+        * `match`: (optional) Matching a requirement (key) in the `require` or `require-dev` of the `composer.json` (`string`)
+        * `matchInverse`: (optional) Inverse matching a requirement (key) in the `require` or `require-dev` of the `composer.json` (`string`)
+        * `action`: The desired action (e.g. `require`) (`string`)
+        * `data`: (optional) The data for the action (e.g. `dompdf/dompdf`) (`string`|`array`)
+        * `options`: (optional) Options for the action (e.g. `--dev`) (`string`)
+
+An example operation for removing `dompdf/dompdf` if it is installed and requiring `iqual/iq_barrio` and `drupal/antibot:^2.0` and updating all depedencies would look like this:
+
+```json
+{
+    "operations": [
+        {
+            "match": "dompdf/dompdf",
+            "action": "remove",
+            "data": "dompdf/dompdf"
+        },
+        {
+            "match": "iqual/iq_barrio",
+            "action": "require",
+            "data": [
+                "iqual/iq_barrio",
+                "drupal/antibot:^2.0",
+            ],
+            "options": "--with-all-dependencies"
+        },
+    ]
+}
+```
+
+<details><summary>Example JSON payload for a complex migration</summary>
+
+```JSON
+{
+    "operations": [
+      {
+        "match": "dompdf/dompdf",
+        "action": "remove",
+        "data": "dompdf/dompdf"
+      },
+      {
+        "match": "zaporylie/composer-drupal-optimizations",
+        "action": "remove",
+        "data": "zaporylie/composer-drupal-optimizations"
+      },
+      {
+        "match": "webflo/drupal-finder",
+        "action": "remove",
+        "data": "webflo/drupal-finder",
+        "options": "--no-update"
+      },
+      {
+        "action": "update",
+        "options": "--lock"
+      },
+      {
+        "action": "commit",
+        "data": "Removed legacy root requirements"
+      },
+      {
+        "action": "rector",
+        "data": "/project/app/public/modules/custom/*"
+      },
+      {
+        "action": "phpcbf",
+        "data": "/project/app/public/modules/custom/",
+        "options": "--standard=Drupal,DrupalPractice --extensions='php,module,inc,install,test,profile,theme,css,info,txt,md,yml'"
+      },
+      {
+        "action": "commit",
+        "data": "Ran rector and code beautifier"
+      },
+      {
+        "action": "config",
+        "key": "extra.project-scaffold.runtime",
+        "data": {
+          "php_version": "8.1"
+        },
+        "options": "--merge"
+      },
+      {
+        "action": "config",
+        "key": "platform.php",
+        "data": "8.1.17"
+      },
+      {
+        "action": "project:scaffold"
+      },
+      {
+        "action": "reboot"
+      },
+      {
+        "match": "iqual/iq_barrio",
+        "action": "require",
+        "data": [
+          "iqual/iq_barrio",
+          "drupal/antibot:^2.0",
+        ],
+        "options": "--with-all-dependencies"
+      },
+      {
+        "action": "update",
+        "options": "--with-all-dependencies"
+      },
+      {
+        "action": "updatedb"
+      },
+      {
+        "action": "config:export"
+      },
+      {
+        "action": "config",
+        "key": "platform",
+        "options": "--unset"
+      }
+    ]
+}
+```
+
+</details>
+
+> In the GitHub web UI you have to make sure to escape double-quotes (e.g. `{\"operations\": [{\"action\": \"config:export\"}]}`).
+
 
 ## Visual Regression Testing
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -120,11 +120,9 @@ An example operation for removing `dompdf/dompdf` if it is installed and requiri
       },
       {
         "action": "rector",
-        "data": "/project/app/public/modules/custom/*"
       },
       {
         "action": "phpcbf",
-        "data": "/project/app/public/modules/custom/",
         "options": "--standard=Drupal,DrupalPractice --extensions='php,module,inc,install,test,profile,theme,css,info,txt,md,yml'"
       },
       {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -22,6 +22,7 @@ The following `make` targets are available in the project's `Makefile`. They can
     * Execute `make db-sync` and `make fs-sync` if the database is empty
     * Runs `drush deploy` (WARNING: This will override config)
 * `update`: Update the Drupal site (`composer` and `drush`) and export the new config
+* `upgrade`: Upgrade the Drupal site by running the `upgrade.sh` script with a `JSON_INPUT`. See the [upgrade workflow documentation](automation.md#upgrade-drupal-project).
 * `theme`: Compile the current Drupal theme (`iq_barrio`)
 * `db-backup`: Alias for db-dump wth `$APP_ROOT/backups` as backup folder
 * `db-dump`: Dump the Drupal database to `$DUMP_FOLDER` (or if not set to `$APP_ROOT`)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,7 @@ Assets and configuration managed by the Drupal Platform has to be customized usi
   * `runtime.php_memory_limit`: PHP memory limit (e.g. `256M`)
 * CI/CD workflow settings
   * `workflows.update`: Enable/Add the Drupal update workflow
+  * `workflows.upgrade`: Enable/Add the Drupal upgrade workflow
   * `workflows.vrt`: Enable/Add the visual regression testing workflow
 * `local_domain_suffix`: The domain suffix for local development
 * Development setup (`development` array)

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -65,10 +65,14 @@ The `.github` directory contains the GitHub Actions workflows for continous inte
 ```
 .github/                               # GitHub Actions Workflows
 ├── actions
-│   └── install-local
-│       └── action.yml                 # Composite action for installing Drupal
+│   ├── install-local
+│   │   └── action.yml                 # Composite action for installing Drupal
+│   └── upgrade
+│       ├── rector.php                 # Default/fallback rector config for upgrade.sh
+│       └── upgrade.sh                 # Composite action for installing Drupal
 ├── workflows
 │   ├── update.yml                     # Automated Drupal Update
+│   ├── upgrade.yml                    # Automated Drupal Upgrades
 │   └── visual-regression-testing.yml  # Automated VRT
 └── ...
 ```


### PR DESCRIPTION
## Tasks

- [x] Add an upgrade GitHub Actions workflow to enable upgrading major versions (including Drupal core) of vendor packages.
- [x] The workflow should support a JSON payload for defining multiple operation steps that should be executed on the local deployment of Drupal in CI/CD (Github Actions).
- [x] Add documentation on the new workflow.