### PR TITLE
#US-1333: Upgrade deprecated github actions

### DIFF
--- a/assets/replace/.github/actions/install-local/action.yml.twig
+++ b/assets/replace/.github/actions/install-local/action.yml.twig
@@ -25,7 +25,7 @@ runs:
       echo "EXECUTION_DATE=$(date --rfc-3339=date)" >> $GITHUB_ENV
 
   - name: Login to Docker Hub
-    uses: docker/login-action@v1
+    uses: docker/login-action@v2
     with:
       username: ${{ inputs.dockerhub_container_registry_user }}
       password: ${{ inputs.dockerhub_container_registry_password }}

--- a/assets/replace/.github/workflows/update.yml.twig
+++ b/assets/replace/.github/workflows/update.yml.twig
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install Drupal locally
       uses: ./.github/actions/install-local
@@ -35,7 +35,7 @@ jobs:
         make cli-local COMMAND="make update COMPOSER_FLAGS=-n DRUSH_FLAGS=-y"
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v5
       with:
         token: ${{ github.event.inputs.token || secrets.GITHUB_TOKEN }}
         commit-message: Updated Drupal site

--- a/assets/replace/.github/workflows/visual-regression-testing.yml.twig
+++ b/assets/replace/.github/workflows/visual-regression-testing.yml.twig
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install Drupal locally
       uses: ./.github/actions/install-local


### PR DESCRIPTION
## Tasks

- [x] Fix [Set-Output Deprecation](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
- [x] Fix [Node.js 12 Deprecation](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)