### PR TITLE
#US-1382: Fix upgrade workflow reviewer issue

### DIFF
--- a/assets/replace/.github/workflows/update.yml.twig
+++ b/assets/replace/.github/workflows/update.yml.twig
@@ -54,6 +54,5 @@ jobs:
 
           Check the logs in the [Github Actions workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more information about the update.
         branch: misc/update-${{ env.EXECUTION_DATE }}
-        reviewers: ${{ github.actor }}
 {% endverbatim -%}
 {% endif %}

--- a/assets/replace/.github/workflows/upgrade.yml.twig
+++ b/assets/replace/.github/workflows/upgrade.yml.twig
@@ -130,6 +130,5 @@ jobs:
 
           Check the logs in the [Github Actions workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more information about the upgrade.
         branch: misc/upgrade-${{ env.EXECUTION_DATE }}
-        reviewers: ${{ github.actor }}
 {% endverbatim -%}
 {% endif %}


### PR DESCRIPTION
## Tasks

- [x] Fix upgrade workflow failing when using a `GITHUB_TOKEN` due to `Review cannot be requested from pull request author`.
  * Remove `reviewers` option from PR creation workflow action
  * Applies to `upgrade.yml` and `update.yml`