### PR TITLE
#US-1464: Fix patch operations in upgrade workflow

### DIFF
--- a/assets/replace/.github/actions/upgrade/upgrade.sh
+++ b/assets/replace/.github/actions/upgrade/upgrade.sh
@@ -196,14 +196,16 @@ for operation in "${OPERATIONS[@]}"; do
       ;;
     "patch-add")
       if grep -q "szeidler/composer-patches-cli" $COMPOSER_JSON_FILE; then
-        rsh composer patch-add ${OPTIONS} -n ${DATA} -d ${APP_ROOT}
+        declare -a "DATA_ARRAY=($DATA)"
+        rsh composer patch-add ${OPTIONS} -n "${DATA_ARRAY[@]}" -d ${APP_ROOT}
       else
         echo "Warning: missing \"szeidler/composer-patches-cli\" package for patch CLI."
       fi
       ;;
     "patch-remove")
       if grep -q "szeidler/composer-patches-cli" $COMPOSER_JSON_FILE; then
-        rsh composer patch-remove ${OPTIONS} -n ${DATA} -d ${APP_ROOT}
+        declare -a "DATA_ARRAY=($DATA)"
+        rsh composer patch-remove ${OPTIONS} -n "${DATA_ARRAY[@]}" -d ${APP_ROOT}
       else
         echo "Warning: missing \"szeidler/composer-patches-cli\" package for patch CLI."
       fi


### PR DESCRIPTION
## Tasks

- [x] Fix `patch-add` and `patch-remove` when using whitespaces in the patch description

## Notes

* The data has to in escaped double quotes when using whitespaces, e.g. `"data": ["drupal/example", "\"example with whitespace\""]` 