### PR TITLE
#US-1814: Deprecate old PHP versions (<v8.0)

### DIFF
--- a/questions.json
+++ b/questions.json
@@ -25,8 +25,6 @@
         "runtime.php_version": {
             "question": "What <info>PHP version</info> should be installed?",
             "options": [
-                "7.3",
-                "7.4",
                 "8.0",
                 "8.1",
                 "8.2"


### PR DESCRIPTION
PHP version 8.0 will hit EOL at the end of the month, while 7.4 has been for a year and 7.3 for two years. The `drupal-platform` should not ask for these versions anymore. It will still support older (and newer) version by settings them directly in the `runtime.php_version` variable. In that case the interactive mode will however fail and scaffolding has to be run non-interactively (i.e. `composer project:scaffold -n`).

## Tasks

- [x] Remove the PHP 7.3 option in the `questions.json`
- [x] Remove the PHP 7.4 option in the `questions.json`