### PR TITLE
#US-1132: Add Solr integration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,15 +91,18 @@ assets/replace/
 │           └── settings.php
 ├── Makefile
 ├── README.md.twig
-└── manifests
-    ├── dev
-    │   └── patch.yml.twig
-    ├── stage
-    │   └── patch.yml.twig
-    ├── prod
-    │   └── patch.yml.twig
-    └── local
-        └── docker-compose.yml.twig
+├── manifests
+│   ├── dev
+│   │   └── patch.yml.twig
+│   ├── stage
+│   │   └── patch.yml.twig
+│   ├── prod
+│   │   └── patch.yml.twig
+│   └── local
+│       └── docker-compose.yml.twig
+└── solr
+    └── site_search
+        └── README.md.twig
 ```
 
 </details>

--- a/assets/replace/@web-root/sites/default/settings.php
+++ b/assets/replace/@web-root/sites/default/settings.php
@@ -58,7 +58,7 @@ if (getenv('SOLR_HOST') && getenv('SOLR_CORE')) {
     $config['search_api.server.solr']['backend_config']['connector_config']['http']['http_user'] = (getenv('SOLR_USER') ?: '');
     $config['search_api.server.solr']['backend_config']['connector_config']['http_pass'] = (getenv('SOLR_PASSWORD') ?: '');
     $config['search_api.server.solr']['backend_config']['connector_config']['http']['http_pass'] = (getenv('SOLR_PASSWORD') ?: '');
-    $config['search_api.server.solr']['name'] = 'Solr - Environment: ' . (getenv('SITE_ENVIRONMENT') ?: '');
+    $config['search_api.server.solr']['name'] = 'Solr - Environment: ' . (getenv('DRUPAL_ENVIRONMENT') ?: '');
 }
 
 /**

--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -132,7 +132,7 @@ delete-local: check-in-container-false
 	@echo -e " $(MSG_WARNING) This will irreversible delete your local database's and container's data. This will not affect code in the repo."
 	echo -n "Do you want to continue? [n] " && read REPLY && [[ $$REPLY == "y" ]] || exit 1
 	docker-compose -p $(COMPOSE_PROJECT_NAME) -f ./manifests/local/docker-compose.yml down -v --remove-orphans || exit 1
-	docker volume rm $(COMPOSE_PROJECT_NAME)_{db,web}_storage 2>/dev/null || true
+	docker volume rm $(COMPOSE_PROJECT_NAME)_{db,web,solr}_storage 2>/dev/null || true
 
 # PHP commands
 xdebug: check-in-container-true ## Enable XDebug

--- a/assets/replace/manifests/local/docker-compose.yml.twig
+++ b/assets/replace/manifests/local/docker-compose.yml.twig
@@ -50,8 +50,7 @@ services:
 
 {% if runtime.solr_version is not null %}
   solr:
-{#    image: {{ runtime.solr_image }}:{{ runtime.solr_image_tag|replace({'VERSION': runtime.solr_version}) }}#}
-    image: solr:9
+    image: {{ runtime.solr_image }}:{{ runtime.solr_image_tag|replace({'VERSION': runtime.solr_version}) }}
     ports:
       - 8983
     volumes:

--- a/assets/replace/manifests/local/docker-compose.yml.twig
+++ b/assets/replace/manifests/local/docker-compose.yml.twig
@@ -14,6 +14,10 @@ x-drupal-variables: &drupal-variables
 {% if runtime.php_memory_limit %}
   PHP_MEMORY_LIMIT: {{ runtime.php_memory_limit }}
 {% endif %}
+{% if runtime.solr_version is not null %}
+  SOLR_HOST: solr
+  SOLR_CORE: site_search
+{% endif %}
 
 services:
   db:
@@ -44,8 +48,28 @@ services:
       - localdev-proxied-webapps
       - default
 
+{% if runtime.solr_version is not null %}
+  solr:
+{#    image: {{ runtime.solr_image }}:{{ runtime.solr_image_tag|replace({'VERSION': runtime.solr_version}) }}#}
+    image: solr:9
+    ports:
+      - 8983
+    volumes:
+      - solr_storage:/var/solr
+      - ../../solr:/mycores
+{% if (locations['project-root'] ~ '/solr/site_search/conf/solrconfig.xml') is existing_file %}
+    command:
+      - solr-precreate
+      - site_search
+      - /mycores/site_search
+{% endif %}
+
+{% endif %}
 volumes:
   db_storage:
+{% if runtime.solr_version is not null %}
+  solr_storage:
+{% endif %}
 
 networks:
   localdev-proxied-webapps:

--- a/assets/replace/solr/site_search/conf/README.md.twig
+++ b/assets/replace/solr/site_search/conf/README.md.twig
@@ -1,0 +1,9 @@
+{% if runtime.solr_version is not null and (locations['project-root'] ~ '/solr/site_search/conf/solrconfig.xml') is not existing_file %}
+# Solr Configuration Directory
+
+In order for the `solr` integration to work properly, you need to add the solr core configuration to this folder. This setup only supports a single `site_search` Solr core.
+
+Make sure to follow the documentation to add the `site_search` Solr configuration. After adding the configuration you have to execute `composer project:scaffold` and reboot your environment.
+
+> This file is removed if a `sorconfig.xml` exists in this directory when `composer project:scaffold` is run.
+{% endif %}

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,10 @@
                 "db_image": "iqualch/dc-mariadb",
                 "db_image_tag": "VERSION",
                 "php_version": 8.1,
-                "db_version": 10.6
+                "db_version": 10.6,
+                "solr_image": "solr",
+                "solr_image_tag": "VERSION",
+                "solr_version": null
             },
             "workflows": {
                 "update": true,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,6 +164,6 @@ rm /project/app/public/config.zip
 composer project:scaffold
 ```
 
-6. Make sure to rebuild the container in VS Code so Solr is started (without a core for initial configuration).
+6. Make sure to rebuild the container in VS Code so Solr is started. This will create the core as configured.
 
 You should now have a running Solr service with a core created from the configuration in the `solr` directory. Follow the Search API module's documentation on how to create indexes.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -153,7 +153,7 @@ composer project:scaffold
 
 3. Make sure to rebuild the container in VS Code so Solr is started (without a core for initial configuration).
 
-4. Add a server in the administration backend of the Drupal Search API module (`/admin/config/search/search-api/add-server`). Use `solr` as host and `site_search` as core.
+4. Add a server in the administration backend of the Drupal Search API module (`/admin/config/search/search-api/add-server`). Use `solr` as server (and system) name, as well as host. Use `site_search` as Solr core name.
 
 5. Download the core configuration and add it to the project repository (e.g. with version `9`):
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -166,4 +166,4 @@ composer project:scaffold
 
 6. Make sure to rebuild the container in VS Code so Solr is started (without a core for initial configuration).
 
-You should now have a running Solr service with a core created from the configuration in the `solr` directory.
+You should now have a running Solr service with a core created from the configuration in the `solr` directory. Follow the Search API module's documentation on how to create indexes.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,7 @@ Assets and configuration managed by the Drupal Platform has to be customized usi
   * `runtime.db_version` [`*`]: Database version of the platform (e.g. `10.6`)
   * `runtime.solr_image`: Solr docker image
   * `runtime.solr_image_tag`: Solr image tag
-  * `runtime.solr_version`: Solr version of the platform (e.g. `9`)
+  * `runtime.solr_version`: Solr version of the platform (e.g. `9.2`)
 * CI/CD workflow settings
   * `workflows.update`: Enable/Add the Drupal update workflow
   * `workflows.upgrade`: Enable/Add the Drupal upgrade workflow
@@ -131,7 +131,7 @@ parameters:
 
 ## Solr
 
-If a `runtime.solr_version` is defined (e.g. `9` instead of `null`) then an additional Solr service will be deployed. This Solr integration only supports a single core with the name `site_search`. Unless a `sorconfig.xml` exists in the `/solr/site_search/conf/` directory, it will not create a core on start-up.
+If a `runtime.solr_version` is defined (e.g. `9.2` instead of `null`) then an additional Solr service will be deployed. This Solr integration only supports a single core with the name `site_search`. Unless a `sorconfig.xml` exists in the `/solr/site_search/conf/` directory, it will not create a core on start-up.
 
 ### Set-up a new Solr core with Search API
 
@@ -144,10 +144,10 @@ composer require drupal/search_api_solr
 drush en search_api_solr
 ```
 
-2. Enable the Solr integration in the Drupal Platform, and set a version (e.g. Solr version `9`):
+2. Enable the Solr integration in the Drupal Platform, and set a version (e.g. Solr version `9.2`, including minor):
 
 ```bash
-composer config extra.project-scaffold.runtime --json '{"solr_version": "9"}' --merge
+composer config extra.project-scaffold.runtime --json '{"solr_version": "9.2"}' --merge
 composer project:scaffold
 ```
 
@@ -155,7 +155,7 @@ composer project:scaffold
 
 4. Add a server in the administration backend of the Drupal Search API module (`/admin/config/search/search-api/add-server`). Use `solr` as server (and system) name, as well as host. Use `site_search` as Solr core name.
 
-5. Download the core configuration and add it to the project repository (e.g. with version `9`):
+5. Download the core configuration and add it to the project repository (e.g. including major version `9`):
 
 ```bash
 drush solr-gsc solr config.zip 9

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -21,6 +21,7 @@ To deploy the local environment run `make deploy-local`. The command will look f
     * PHP CLI
     * Nginx
 * MariaDB database container
+* Solr search API container (Optional)
 
 ## Remote Deployment (Kubernetes)
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -9,7 +9,8 @@ The project is structured according to the following top-level layout:
 ├── .github                     # GitHub Actions Workflows
 ├── .vscode                     # VS Code config
 ├── app                         # Drupal app directory
-└── manifests                   # Deployment manifests
+├── manifests                   # Deployment manifests
+└── solr                        # Solr core configuration (optional)
 ```
 
 ## Drupal app directory


### PR DESCRIPTION
Add the option for a Solr service in the local dev setup.

## Tasks

- [x] Add Solr integration for local dev in `docker-compose.yml`
- [x] Add documentation on setting up Solr
- [x] Beta testing

## Notes

* Only supports a `search_api_solr` setup and a single `site_search` core by default
* A `sorconfig.xml` is required in the `/solr/site_search/conf/` directory for a proper start-up
  * See documented steps