### PR TITLE
#US-1896: Fix `robots.txt` handling on multi-domain for Platform.sh

### DIFF
--- a/assets/merge/.platform.app.yaml.twig
+++ b/assets/merge/.platform.app.yaml.twig
@@ -138,9 +138,7 @@ web:
                 '\.(jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
                     allow: true
                 ^/robots\.txt$:
-                    allow: false
-                    # Handle robots.txt with PHP for multi-domain setup
-                    passthru: /index.php
+                    allow: true
                 ^/sitemap\.xml$:
                     allow: true
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -61,6 +61,8 @@ The `platform.app.yaml` configuration file can be customized, e.g. to add cronjo
 
 #### Multi-Domain Setup
 
+##### Routing
+
 For multi-domain setups the additional domains need to defined in the `.platform/routes.yaml` file. To enable automatic hostname overrides for development environments a `domain.record` can be set in the `attributes` section of the corresponding route. This will be automatically converted into a configuration override in the `settings.platformsh.php` when on a non-production branch.
 
 Example route for an additional domain `www.example.ch` that will override the `hostname` in the `domain.record.example_ch` config to `www.example.ch`:
@@ -82,3 +84,21 @@ Example route for an additional domain `www.example.ch` that will override the `
 ```
 
 > Make sure to also add the respective domain record attributes to the default route.
+
+##### Robots.txt
+
+If the `robots.txt` should be routed through PHP/Drupal then the drupal scaffold's file mapping for the `robots.txt` file has to be disabled and then the file has to be removed from the repository. This is usually required in a multi-domain setup, as there should be different versions of the `robots.txt` per domain.
+
+For example the drupal scaffold file mapping in the `composer.json` could look like this:
+
+```json
+    "drupal-scaffold": {
+        "locations": {
+            "project-root": ".",
+            "web-root": "public"
+        },
+        "file-mapping": {
+            "[web-root]/robots.txt": false
+        }
+    },
+```


### PR DESCRIPTION
## Issue

Currently the location rule in the `.platform.app.yaml` is disallowing file system assets and passes the `robots.txt` to PHP which doesn’t find it ([here](https://github.com/iqual-ch/drupal-platform/blob/5f181922b7cd1964ed0dc7c065ebbab8c78e83f4/assets/merge/.platform.app.yaml.twig#L140-L143)). The `passthru` is however redundant. This should be changed to `allow: true` and the `passthru` removed.

The implication is: For a multi-domain setup it is now required that the `robots.txt` file is removed from the repository and the drupal scaffold file mapping is disabled in the`extra.drupal-scaffold.file-mapping` composer config by setting it to `"[web-root]/robots.txt": false`.

## Tasks

- [x] Fix `robots.txt` location rule in `.platform.app.yaml`
- [x] Update documentation