### PR TITLE
#PF-419: Fix `error_level` for production environment on Platform.sh

### DIFF
--- a/assets/replace/@web-root/sites/default/settings.platformsh.php.twig
+++ b/assets/replace/@web-root/sites/default/settings.platformsh.php.twig
@@ -38,7 +38,7 @@ if ($platformsh->hasRelationship('database')) {
 // on development but not production.
 if (isset($platformsh->branch)) {
   // Production type environment.
-  if ($platformsh->onProduction() || $platformsh->onDedicated()) {
+  if ($platformsh->branch == 'main' || $platformsh->onProduction() || $platformsh->onDedicated()) {
     $config['system.logging']['error_level'] = 'hide';
   }
   // Development type environment.


### PR DESCRIPTION
## Issue

The `system.logging` `error_level` is set to `verbose` on production. It should be `hide`. This is due to the drupal platform relying on `onProduction()` by Platform.sh config reader [here](https://github.com/iqual-ch/drupal-platform/blob/v1.6.1/assets/replace/%40web-root/sites/default/settings.platformsh.php.twig#L41). However that expects `master` instead of `main` [here](https://github.com/platformsh/config-reader-php/blob/2.4.1/src/Config.php#L440).

## Tasks

- [x] Fix production detection on Platform.sh