### PR TITLE
#PF-469: Fix serving static html files in the web root

### DIFF
--- a/assets/merge/.platform.app.yaml.twig
+++ b/assets/merge/.platform.app.yaml.twig
@@ -141,6 +141,8 @@ web:
                     allow: true
                 ^/sitemap\.xml$:
                     allow: true
+                '^/[^/]+\.html$':
+                    allow: true
 
                 # Allow access to pagedesigner templates.
                 '^/themes/custom/[^/]+/templates/includes/[^/]+\.twig$':


### PR DESCRIPTION
Issue

Static HTML files in the `public` web root of a project are not served by the current locations setup in the `.platform.app.yaml`. This removes the ability to add Google site verification files to the root of the project for verifying a website in the Google Search Console.

## Tasks

- [x] Fix serving static html files in the web root in the `.platform.app.yaml`