### PR TITLE
#PF-470: Fix `avif` and `webp` static file support

### DIFF
--- a/assets/merge/.platform.app.yaml.twig
+++ b/assets/merge/.platform.app.yaml.twig
@@ -135,7 +135,7 @@ web:
             # Rules for specific URI patterns.
             rules:
                 # Allow access to common static files.
-                '\.(jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
+                '\.(avif|webp|jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
                     allow: true
                 ^/robots\.txt$:
                     allow: true


### PR DESCRIPTION
## Issue

Currently `avif` and `webp` files are not allowed outside of the `/sites/default/files` files route. To support these modern image formats in modules or themes, it should be added to the allowed static files list. See the [official Drupal 10 template from Platform.sh](https://github.com/platformsh-templates/drupal10/blob/master/.platform.app.yaml#L118).

## Tasks

- [x] Add `avif` and `webp` file support to `.platform.app.yaml`