### PR TITLE
#PF-471: Add missing Drupal files associations

### DIFF
--- a/assets/replace/.vscode/settings.json.twig
+++ b/assets/replace/.vscode/settings.json.twig
@@ -24,6 +24,17 @@
       "password": "drupal"
     }
   ],
+  "files.associations": {
+    "*.inc": "php",
+    "*.module": "php",
+    "*.install": "php",
+    "*.theme": "php",
+    "*.profile": "php",
+    "*.tpl.php": "php",
+    "*.test": "php",
+    "*.php": "php",
+    "*.info": "ini"
+  },
   "git.autofetch": true,
   "[php]": {
     "editor.defaultFormatter": "wongjn.php-sniffer"


### PR DESCRIPTION
## Issue

The file associations for Drupal-specific PHP files are missing from the VS Code settings (e.g. `.module`, or `.theme`).

## Tasks

- [x] Add missing files associations for Drupal ([see here](https://www.drupal.org/docs/develop/development-tools/editors-and-ides/configuring-visual-studio-code#s-editor-settings))