### PR TITLE
#PF-423: Fix multi-domain for non-prod env on `main`

### DIFF
--- a/assets/replace/@web-root/sites/default/settings.platformsh.php.twig
+++ b/assets/replace/@web-root/sites/default/settings.platformsh.php.twig
@@ -44,17 +44,19 @@ if (isset($platformsh->branch)) {
   // Development type environment.
   else {
     $config['system.logging']['error_level'] = 'verbose';
+  }
+}
 
-    // Enable adding domain record hostname overrides for development environments
-    // by setting an "domain.record" attribute on a route.
-    $routes = $platformsh->getUpstreamRoutes();
-    foreach($routes as $route) {
-      if (array_key_exists("attributes", $route) && array_key_exists("domain.record", $route["attributes"])) {
-        $url = $route['url'];
-        $parsedUrl = parse_url($url);
-        $domainRecord = $route["attributes"]["domain.record"];
-        $config['domain.record.' . $domainRecord]['hostname'] = $parsedUrl['host'];
-      }
+// Enable adding domain record hostname overrides for development environments
+// by setting an "domain.record" attribute on a route.
+if (getenv('PLATFORM_ENVIRONMENT_TYPE') != 'production') {
+  $routes = $platformsh->getUpstreamRoutes();
+  foreach($routes as $route) {
+    if (array_key_exists("attributes", $route) && array_key_exists("domain.record", $route["attributes"])) {
+      $url = $route['url'];
+      $parsedUrl = parse_url($url);
+      $domainRecord = $route["attributes"]["domain.record"];
+      $config['domain.record.' . $domainRecord]['hostname'] = $parsedUrl['host'];
     }
   }
 }


### PR DESCRIPTION
## Issue

It is not be possible to access multi-domain sites on non-prod when on the `main` branch using Platform.sh due to the fix in #32.
 
## Task

- [x] Instead of checking for `main`, check for the environment type when setting `domain.record` overrides