### PR TITLE
#PF-422: Fix `fontyourface` support

### DIFF
--- a/assets/replace/@app-root/resources/build.sh.twig
+++ b/assets/replace/@app-root/resources/build.sh.twig
@@ -13,5 +13,10 @@ if [ -d "./public/modules/custom" ]; then
   mkdir -p ./build/public/modules/custom
   mv ./public/modules/custom ./build/public/modules/
 fi
+
+if [ -d "./public/sites/default/files/fontyourface" ]; then
+  mkdir -p ./build/public/sites/default/files/fontyourface
+  mv ./public/sites/default/files/fontyourface ./build/public/sites/default/files/
+fi
 {% endverbatim -%}
 {% endif %}

--- a/assets/replace/@app-root/resources/deploy.sh.twig
+++ b/assets/replace/@app-root/resources/deploy.sh.twig
@@ -15,6 +15,11 @@ if [ -d "./build/public/modules/custom/" ]; then
   rsync -a ./build/public/modules/custom/ ./public/modules/custom --delete
 fi
 
+# Deploy repository assets
+if [ -d "./build/public/sites/default/files/" ]; then
+  rsync -a ./build/public/sites/default/files/ ./public/sites/default/files
+fi
+
 # We don't want to run drush commands if drupal isn't installed.
 if [ -n "$(drush status --fields=bootstrap)" ]; then
   drush deploy


### PR DESCRIPTION
## Issue

The `fontyourface` folder in the repository is in the `publis/sites/default/files` mount. Files present during the build phase (including the ones in the repository) can’t be deployed to mounted folders if they’re not empty. This has already been mitigated for the SCSS compilation of `iq_custom`. The same, or a similar, approach should be implemented for these kind of asset files.

## Tasks

- [x] Add support for `fontyourface` in the `build.sh` and `deploy.sh` scripts