### PR TITLE
#PF-467: Added `ready_for_review` trigger on `pull_request`

### DIFF
--- a/assets/replace/.github/workflows/testing.yml.twig
+++ b/assets/replace/.github/workflows/testing.yml.twig
@@ -8,7 +8,7 @@ env:
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, ready_for_review]
 
 concurrency:
   group: ci-drupal-testing-${{ github.ref }}


### PR DESCRIPTION
## Issue

Currently testing workflows will only run when `opening` or `reopening` pull requests. Instead of forcing developers to re-open PRs, add the `ready_for_review` trigger so it is possible to put PRs into draft and then set them to ready for review.

## Tasks

- [x] Add `ready_for_review` trigger on `pull_request` in `testing.yml`