### PR TITLE
#PF-466: Add option for no-remote deployment for Platform.sh

### DIFF
--- a/assets/replace/@app-root/resources/deploy.sh.twig
+++ b/assets/replace/@app-root/resources/deploy.sh.twig
@@ -4,7 +4,7 @@
 
 set -e
 
-if [ -z "$DRUPAL_NO_DEPLOY" ]; then
+if [ -n "$DRUPAL_NO_DEPLOY" ]; then
   echo "Deployment disabled."
   exit 0
 fi

--- a/assets/replace/@app-root/resources/deploy.sh.twig
+++ b/assets/replace/@app-root/resources/deploy.sh.twig
@@ -4,6 +4,11 @@
 
 set -e
 
+if [ -z "$DRUPAL_NO_DEPLOY" ]; then
+  echo "Deployment disabled."
+  exit 0
+fi
+
 # Generate Drush config for Platform.sh
 php ./drush/platformsh_generate_drush_yml.php
 
@@ -21,7 +26,7 @@ if [ -d "./build/public/sites/default/files/" ]; then
 fi
 
 # We don't want to run drush commands if drupal isn't installed.
-if [ -n "$(drush status --fields=bootstrap)" ] && [ -z "$DRUPAL_NO_DEPLOY" ]; then
+if [ -n "$(drush status --fields=bootstrap)" ] && [ -z "$DRUPAL_NO_DRUSH_DEPLOY" ]; then
   drush deploy
 else
   echo "Drupal not installed. Skipping standard Drupal deploy steps"

--- a/assets/replace/@app-root/resources/deploy.sh.twig
+++ b/assets/replace/@app-root/resources/deploy.sh.twig
@@ -21,7 +21,7 @@ if [ -d "./build/public/sites/default/files/" ]; then
 fi
 
 # We don't want to run drush commands if drupal isn't installed.
-if [ -n "$(drush status --fields=bootstrap)" ]; then
+if [ -n "$(drush status --fields=bootstrap)" ] && [ -z "$DRUPAL_NO_DEPLOY" ]; then
   drush deploy
 else
   echo "Drupal not installed. Skipping standard Drupal deploy steps"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -102,3 +102,9 @@ For example the drupal scaffold file mapping in the `composer.json` could look l
         }
     },
 ```
+
+#### Auto-Deployment
+
+Drupal will be built and deployed automatically by default. This includes running database updates, config imports and cache rebuilds (i.e. `drush deploy`). On deployment the state from the repository will be deployed. Config changes will be overridden.
+
+> If this is not the desired behavior, set the `DRUPAL_NO_DEPLOY` environment variable in Platform.sh (env/project) so Drupal is not automatically deployed using `drush deploy`. This can be helpful for restoring backups or automation.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -105,6 +105,6 @@ For example the drupal scaffold file mapping in the `composer.json` could look l
 
 #### Auto-Deployment
 
-Drupal will be built and deployed automatically by default. This includes running database updates, config imports and cache rebuilds (i.e. `drush deploy`). On deployment the state from the repository will be deployed. Config changes will be overridden.
+Drupal will be built and deployed automatically by default on Platform.sh. This includes running database updates, config imports and cache rebuilds (i.e. `drush deploy`) as well as copying repository assets (e.g. `fontyourface` fonts). On deployment the state from the repository will be deployed. Config changes will be overridden.
 
-> If this is not the desired behavior, set the `DRUPAL_NO_DEPLOY` environment variable in Platform.sh (env/project) so Drupal is not automatically deployed using `drush deploy`. This can be helpful for restoring backups or automation.
+> If this is not the desired behavior, set the `DRUPAL_NO_DEPLOY` environment variable in Platform.sh (env/project) so the deployment script doesn't run. If only `drush deploy` should be disabled, use `DRUPAL_NO_DRUSH_DEPLOY`. This can be helpful for restoring backups or automation.


### PR DESCRIPTION
## Issue

Currently Drupal is always built and deployed automatically by default on Platform.sh. This can lead to issues when restoring backups or for automation where you do not want to run any database hooks (config import or update hooks) or change any assets.

## Tasks

- [x] Add an option (e.g. environment variable) so drush deploy is not executed during the deployment hook.
- [x] Add an option to not run deployment script at all

## Restrictions

* When only disabling `drush deploy` then themes or assets might still be overwritten from the build phase but not compiled (e.g. `css` in `iq_barrio`.
* When disabling the deployment script altogether custom module and theme code might not be up to date.