### PR TITLE
#PF-486: Add multi-domain support for testing

### DIFF
--- a/assets/replace/.github/workflows/phpunit-functional-testing.yml.twig
+++ b/assets/replace/.github/workflows/phpunit-functional-testing.yml.twig
@@ -3,7 +3,7 @@ name: PHPUnit functional testing
 
 env:
   DOCKER_WEB_PORT: 80:80
-  DOCKER_NETWORK: {{ project_name|default(name ~ '-sw-project') }}_default
+  DOCKER_WEB_NETWORK: {{ project_name|default(name ~ '-sw-project') }}_default
 
 {% verbatim -%}
 on:
@@ -109,7 +109,7 @@ jobs:
       run: |
         curl --fail --retry 3 --retry-delay 10 -Lso /dev/null http://localhost || \
           (echo 'Accessing homepage of Drupal site failed.' && exit 1)
-        docker network connect ${{ env.DOCKER_NETWORK }} --alias chrome ${{ job.services.chrome.id }}
+        docker network connect ${{ env.DOCKER_WEB_NETWORK }} --alias chrome ${{ job.services.chrome.id }}
         make cli-local COMMAND='make phpunit-browser PHPUNIT_FLAGS="--log-junit TEST-phpunit.xml"'
 
     - name: Publish Test Report

--- a/assets/replace/.github/workflows/phpunit-functional-testing.yml.twig
+++ b/assets/replace/.github/workflows/phpunit-functional-testing.yml.twig
@@ -1,10 +1,11 @@
 {% if workflows.phpunit %}
-{%- verbatim -%}
 name: PHPUnit functional testing
 
 env:
   DOCKER_WEB_PORT: 80:80
+  DOCKER_NETWORK: {{ project_name|default(name ~ '-sw-project') }}_default
 
+{% verbatim -%}
 on:
   workflow_dispatch:
     inputs:
@@ -108,7 +109,7 @@ jobs:
       run: |
         curl --fail --retry 3 --retry-delay 10 -Lso /dev/null http://localhost || \
           (echo 'Accessing homepage of Drupal site failed.' && exit 1)
-        docker network connect localdev-proxied-webapps --alias chrome ${{ job.services.chrome.id }}
+        docker network connect ${{ env.DOCKER_NETWORK }} --alias chrome ${{ job.services.chrome.id }}
         make cli-local COMMAND='make phpunit-browser PHPUNIT_FLAGS="--log-junit TEST-phpunit.xml"'
 
     - name: Publish Test Report

--- a/assets/replace/manifests/local/docker-compose.yml.twig
+++ b/assets/replace/manifests/local/docker-compose.yml.twig
@@ -45,8 +45,18 @@ services:
     volumes:
       - ./../..:/project
     networks:
+{% if local_domain_aliases is empty %}
       - localdev-proxied-webapps
       - default
+{% else %}
+      localdev-proxied-webapps:
+      default:
+        aliases:
+          - {{ project_name|default(name ~ '-sw-project') }}.{{ local_domain_suffix }}
+{% for alias in local_domain_aliases %}
+          - {{ alias }}.{{ project_name|default(name ~ '-sw-project') }}.{{ local_domain_suffix }}
+{% endfor %}
+{% endif %}
 
 {% if runtime.solr_version is not null %}
   solr:

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
                 "phpunit": false
             },
             "local_domain_suffix": "localdev.iqual.ch",
+            "local_domain_aliases": [],
             "development": [
                 "devcontainer-docker-compose"
             ],

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,7 @@ Assets and configuration managed by the Drupal Platform has to be customized usi
   * `workflows.phpunit`: Enable/Add the Drupal testing workflow
   * `workflows.vrt`: Enable/Add the visual regression testing workflow
 * `local_domain_suffix`: The domain suffix for local development
+* `local_domain_aliases` array: Additional aliases of the local development domain in the Docker network
 * Development setup (`development` array)
   * `devcontainer-docker-compose`: Local dev environment with docker-compose and devcontainers
 * `deployment`: Deployment integration type, see [available remote deployment options](./deployment.md#remote-deployment)

--- a/docs/drupal-development.md
+++ b/docs/drupal-development.md
@@ -113,6 +113,10 @@ For running the project specific PHPUnit tests, there are multiple avaiable PHPU
 
 > `phpunit` has to be required in the project, including DTT.
 
+### Multi-Domain testing
+
+By default only the `web` hostname can be tested against using PHPUnit tests that request the website using curl or Chrome. To add more aliases (subdomains) to be accessible during testing, add a list of aliases to a `local_domain_aliases` array in the `extra.project-scaffold` section of the project's `composer.json` and run `composer project:scaffold`. After rebuilding your VS Code environment, these additional aliases will be accessible within the Docker network (e.g. local domain alias `foo` in a `bar` project will add a `foo.bar-sw-project.localdev.iqual.ch` alias).
+
 ## PHPCS
 
 For code sniffing there is a make target that will run sniffing according to the Drupal standard on the custom themes & modules in the repository called `make phpcs`. To run both PHPCS and some basic PHP linting first, there is also `make lint`.


### PR DESCRIPTION
## Issue

By default only the `web` hostname can be tested against using PHPUnit tests that request the website using curl or Chrome. But for multi-domain projects (using the `domain` module) this doesn't allow for testing different domains locally, as the local development URLs (e.g. `example-sw-project.localdev.iqual.ch`) will resolve to `127.0.0.1`, when in reality the service is at the `web` hostname.

To support testing different domains in the local docker network, aliases for the local development domains should be added to the `default` network. This requires the addition of subdomain aliases in the `composer.json`

## Tasks

- [x] Add `local_domain_aliases` configuration variable (array)
- [x] Conditionally add these aliases to the `docker-compose.yml` `default` network of the `web` service
- [x] Change the network connection of the `chrome` service in the `phpunit-functional-testing.yml` workflow
- [x] Add documentation

## Restrictions

* The `web` service doesn't support HTTPS while the local reverse proxy or remote deployments require it. To work around this issue, the `scheme` can be set to `variable` in a local settings override for the domain records.
  * Example: `$config['domain.record.example_ch']['scheme'] = 'variable';` in `local.settings.php`
