### PR TITLE
#PF-505: Graceful `phpcs` warnings and disable `css` sniffing

### DIFF
--- a/assets/replace/.github/workflows/phpcs.yml.twig
+++ b/assets/replace/.github/workflows/phpcs.yml.twig
@@ -51,6 +51,7 @@ jobs:
     - name: "Run PHPCS"
       shell: bash
       run: |
-        make phpcs APP_ROOT="${{ github.workspace }}/app" PHPCS_FLAGS="-q --report=checkstyle" | cs2pr
+        make phpcs APP_ROOT="${{ github.workspace }}/app" PHPCS_FLAGS="-q --report=checkstyle" \
+          | cs2pr --graceful-warnings
 {% endverbatim -%}
 {% endif %}

--- a/assets/replace/@app-root/resources/utility.mk
+++ b/assets/replace/@app-root/resources/utility.mk
@@ -67,6 +67,7 @@ phpcs:
 	pushd $(APP_ROOT) > /dev/null
 	REPO_CODE="$$(git ls-tree -d -r $$(git write-tree) --name-only | grep -E '(themes|modules)/custom/[^/]+$$' | paste -s -)"
 	phpcs --standard=Drupal,DrupalPractice \
+		--runtime-set ignore_warnings_on_exit 1 \
 		--extensions=php,module,inc,install,test,profile,theme,css,info,txt,md,yml \
 		--ignore=node_modules,bower_components,vendor,custom.css $(PHPCS_FLAGS) \
 		$$REPO_CODE

--- a/assets/replace/@app-root/resources/utility.mk
+++ b/assets/replace/@app-root/resources/utility.mk
@@ -68,7 +68,7 @@ phpcs:
 	REPO_CODE="$$(git ls-tree -d -r $$(git write-tree) --name-only | grep -E '(themes|modules)/custom/[^/]+$$' | paste -s -)"
 	phpcs --standard=Drupal,DrupalPractice \
 		--runtime-set ignore_warnings_on_exit 1 \
-		--extensions=php,module,inc,install,test,profile,theme,css,info,txt,md,yml \
+		--extensions=php,module,inc,install,test,profile,theme,info,txt,md,yml \
 		--ignore=node_modules,bower_components,vendor,custom.css $(PHPCS_FLAGS) \
 		$$REPO_CODE
 


### PR DESCRIPTION
## Issues

* When there is any warning from `phpcs` it will exit with a non-zero code.
* Also `cs2pr` will exit with a non-zero code on a warning.
* `.css` files are being sniffed, even though they are compiled.

## Tasks

- [x] Add `graceful-warnings` flag to `cs2pr`
- [x] Add `ignore_warnings_on_exit` runtime flag to `phpcs`
- [x] Remove `css` extension from `phpcs`