### PR TITLE
#PF-488: Update GitHub Actions workflows

### DIFF
--- a/assets/replace/.github/actions/install-local/action.yml.twig
+++ b/assets/replace/.github/actions/install-local/action.yml.twig
@@ -37,7 +37,7 @@ runs:
       password: ${{ inputs.dockerhub_container_registry_password }}
 
   - name: Cache Docker images
-    uses: ScribeMD/docker-cache@0.3.6
+    uses: ScribeMD/docker-cache@0.5.0
     with:
       key: ${{ runner.os }}-docker-${{ hashFiles('**/docker-compose.yml') }}
 

--- a/assets/replace/.github/actions/install-local/action.yml.twig
+++ b/assets/replace/.github/actions/install-local/action.yml.twig
@@ -44,7 +44,7 @@ runs:
   - name: Cache Composer dependency
     if: ${{ inputs.caching == 'true' }}
     id: cache-composer
-    uses: actions/cache@v3
+    uses: actions/cache@v4
     with:
       path: |
         ./.composer
@@ -53,7 +53,7 @@ runs:
   - name: Cache Drupal database
     if: ${{ inputs.caching == 'true' }}
     id: cache-db
-    uses: actions/cache@v3
+    uses: actions/cache@v4
     with:
       path: |
         ./app/backups

--- a/assets/replace/.github/workflows/phpunit-functional-testing.yml.twig
+++ b/assets/replace/.github/workflows/phpunit-functional-testing.yml.twig
@@ -73,7 +73,7 @@ jobs:
 
     - name: Upload HTML output
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: phpunit-db-report
         path: ./app/public/sites/simpletest/browser_output
@@ -123,7 +123,7 @@ jobs:
 
     - name: Upload HTML output
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: phpunit-browser-report
         path: ./app/public/sites/simpletest/browser_output

--- a/assets/replace/.github/workflows/update.yml.twig
+++ b/assets/replace/.github/workflows/update.yml.twig
@@ -35,7 +35,7 @@ jobs:
         make cli-local COMMAND="make update COMPOSER_FLAGS=-n DRUSH_FLAGS=-y"
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v6
       with:
         token: ${{ github.event.inputs.token || secrets.GITHUB_TOKEN }}
         commit-message: Updated Drupal site

--- a/assets/replace/.github/workflows/upgrade.yml.twig
+++ b/assets/replace/.github/workflows/upgrade.yml.twig
@@ -105,7 +105,7 @@ jobs:
         make upgrade
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v6
       with:
         token: ${{ github.event.inputs.token || secrets.GITHUB_TOKEN }}
         commit-message: Upgraded Drupal site


### PR DESCRIPTION
## Issues

Some GitHub Actions workflows are outdated and need updating. [Node v16 will also be deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).

## Tasks

- [x] Updated `ScribeMD/docker-cache` to v0.5
- [x] Update `actions/cache` to v4
- [x] Update `actions/upload-artifact` to v4 ([Deprecation](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/))
- [x] Update `peter-evans/create-pull-request` to v6