### PR TITLE
#PF-507: Deprecate Docker Compose v1

### DIFF
--- a/assets/replace/@app-root/resources/deploy.mk.twig
+++ b/assets/replace/@app-root/resources/deploy.mk.twig
@@ -14,11 +14,7 @@ cli-%: check-in-container-false ## Attach to environment %
 		EXEC_FLAG=
 	fi
 	if [[ $* == "local" ]]; then
-		if [[ "$$(docker-compose --version --short)" == "2."* ]]; then
-			docker exec $$EXEC_FLAG --user $(REMOTE_USER) --workdir /project $(COMPOSE_PROJECT_NAME)-$(REMOTE_CONTAINER)-1 bash -l -c "$$EXEC_COMMAND"
-		else
-			docker exec $$EXEC_FLAG --user $(REMOTE_USER) --workdir /project $(COMPOSE_PROJECT_NAME)_$(REMOTE_CONTAINER)_1 bash -l -c "$$EXEC_COMMAND"
-		fi
+		docker exec $$EXEC_FLAG --user $(REMOTE_USER) --workdir /project $(COMPOSE_PROJECT_NAME)-$(REMOTE_CONTAINER)-1 bash -l -c "$$EXEC_COMMAND"
 	else
 		{%~ if deployment == "kubernetes" %}
 		K8S_CONTEXT="$(K8S_$(shell echo $* | tr a-z A-Z)_CONTEXT)"
@@ -67,7 +63,7 @@ deploy-%: check-in-container-false ## Deploy environment %
 
 deploy-%-compose: check-in-container-false env-local
 	@echo "Deploying $* docker-compose manifests"
-	docker-compose -p $(COMPOSE_PROJECT_NAME) -f ./manifests/$*/docker-compose.yml up $(COMPOSE_FLAGS)
+	docker compose -p $(COMPOSE_PROJECT_NAME) -f ./manifests/$*/docker-compose.yml up $(COMPOSE_FLAGS)
 
 {% if deployment == "kubernetes" %}
 deploy-%-kubectl: check-in-container-false
@@ -89,5 +85,5 @@ deploy-%-kubectl-patch: check-in-container-false
 delete-local: check-in-container-false
 	@echo -e " $(MSG_WARNING) This will irreversible delete your local database's and container's data. This will not affect code in the repo."
 	echo -n "Do you want to continue? [n] " && read REPLY && [[ $$REPLY == "y" ]] || exit 1
-	docker-compose -p $(COMPOSE_PROJECT_NAME) -f ./manifests/local/docker-compose.yml down -v --remove-orphans || exit 1
+	docker compose -p $(COMPOSE_PROJECT_NAME) -f ./manifests/local/docker-compose.yml down -v --remove-orphans || exit 1
 	docker volume rm $(COMPOSE_PROJECT_NAME)_{db,web,solr}_storage 2>/dev/null || true

--- a/assets/replace/@app-root/resources/utility.mk
+++ b/assets/replace/@app-root/resources/utility.mk
@@ -30,7 +30,7 @@ env-%:
 # Tool commands
 tool-%: ## Launch tools
 	@echo -e "Launching tooling: $*"
-	docker-compose -p $(COMPOSE_PROJECT_NAME) --profile $* -f ./manifests/local/docker-compose.yml up -d $*
+	docker compose -p $(COMPOSE_PROJECT_NAME) --profile $* -f ./manifests/local/docker-compose.yml up -d $*
 
 # PHP commands
 xdebug: check-in-container-true ## Enable XDebug


### PR DESCRIPTION
## Issue

[Docker Compose V1 has been deprecated](https://docs.docker.com/compose/migrate/). [GitHub Actions has also dropped support](https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/) ([Removed in 2024-07-30 Ubuntu 22.04 release](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240730.2)).

Remove the support from the Drupal Platform.  Since GitHub Actions has dropped support, this will need a migration script.

> [!CAUTION]
> This could break some local setups still relying on Docker Compose v1 and will require an upgrade to v2.

## Tasks

- [x] Change `docker-compose` to `docker compose`
- [x] Remove support for both v1 and v2 of Docker Compose