### PR TITLE
Remove "de" suffix from robots.txt.twig

### DIFF
--- a/assets/replace/@app-root/resources/robots.txt.twig
+++ b/assets/replace/@app-root/resources/robots.txt.twig
@@ -1,1 +1,1 @@
-Sitemap: {{ url }}/de/sitemap.xml
+Sitemap: {{ url }}/sitemap.xml


### PR DESCRIPTION
Realated to https://support-iqual.atlassian.net/browse/SWCA-61

Drupal should handle the redirect to the language specific map, thus the suffix is not necessary.