### PR TITLE
DUP-194: Remove deprecated assertions

### DIFF
--- a/assets/add/@web-root/sites/default/local.settings.php.twig
+++ b/assets/add/@web-root/sites/default/local.settings.php.twig
@@ -8,12 +8,6 @@
  *
  */
 
- /**
- * Assertions.
- */
-assert_options(ASSERT_ACTIVE, TRUE);
-\Drupal\Component\Assertion\Handle::register();
-
 /**
  * Create a temporary salt for local development in the private files
  */


### PR DESCRIPTION
## Issue

The `assert_options(ASSERT_ACTIVE, TRUE);` and `\Drupal\Component\Assertion\Handle::register();` [has been deprecated](https://www.drupal.org/node/3391611). We should switch to using `zend.assertions = 1`.

## Tasks

- [x] Remove deprecated assertions from `local.settings.php` file