### PR TITLE
PF-512: Add DDEV GitHub Actions Workflows

### DIFF
--- a/assets/merge/.gitignore.twig
+++ b/assets/merge/.gitignore.twig
@@ -94,6 +94,10 @@ app/backups/
 # Ignore maintenance file
 maintenance_*.html
 
+# Ignore DDEV Secrets and CI config
+.ddev/homeadditions/.ssh
+.ddev/config.ci.yaml
+
 # Ignore DDEV chrome add-on
 .ddev/addon-metadata/*chrome/manifest.yaml
 .ddev/*-chrome.yaml

--- a/assets/merge/.gitignore.twig
+++ b/assets/merge/.gitignore.twig
@@ -98,3 +98,8 @@ maintenance_*.html
 .ddev/addon-metadata/*chrome/manifest.yaml
 .ddev/*-chrome.yaml
 .ddev/*-chrome_extras.yaml
+
+# Ignore Playwright folders
+playwright-report/
+playwright-snapshots/
+playwright-tmp/

--- a/assets/merge/.gitignore.twig
+++ b/assets/merge/.gitignore.twig
@@ -93,3 +93,8 @@ app/backups/
 
 # Ignore maintenance file
 maintenance_*.html
+
+# Ignore DDEV chrome add-on
+.ddev/addon-metadata/*chrome/manifest.yaml
+.ddev/*-chrome.yaml
+.ddev/*-chrome_extras.yaml

--- a/assets/merge/playwright-vrt.config.json.twig
+++ b/assets/merge/playwright-vrt.config.json.twig
@@ -1,0 +1,4 @@
+{
+  "referenceUrl": "{{ url }}",
+  "testUrl": "https://{{ name }}.ddev.site"
+}

--- a/assets/replace/.ddev/commands/web/lint
+++ b/assets/replace/.ddev/commands/web/lint
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## Description: Run PHP Linting
+## Usage: lint [path]
+## Example: "ddev lint public/modules/custom/foobar"
+## HostWorkingDir: true
+
+if [[ -x "$(command -v parallel-lint)" ]]; then
+  parallel-lint "$@" -e php,module,theme,inc,install,profile
+else
+  find "$@" \( -name '*.php' -o -name '*.module' -o -name '*.theme' -o -name '*.inc' -o -name '*.install' -o -name '*.profile' \) -exec php -l {} \;
+fi

--- a/assets/replace/.ddev/commands/web/phpcbf
+++ b/assets/replace/.ddev/commands/web/phpcbf
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+## Description: Run phpcbf inside the web container.
+## Usage: phpcbf [args]
+## Example: "ddev phpcbf"
+## HostWorkingDir: true
+## ExecRaw: true
+
+phpcbf "$@"

--- a/assets/replace/.ddev/commands/web/phpcs
+++ b/assets/replace/.ddev/commands/web/phpcs
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+## Description: Run phpcs inside the web container.
+## Usage: phpcs [args]
+## Example: "ddev phpcs"
+## HostWorkingDir: true
+## ExecRaw: true
+
+phpcs "$@"

--- a/assets/replace/.ddev/commands/web/phpstan
+++ b/assets/replace/.ddev/commands/web/phpstan
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+## Description: Run PHPStan
+## Usage: phpstan [flags] [args]
+## Example: "ddev phpstan --configuration=./app/phpstan.neon analyse app/public/modules/custom/foobar"
+## HostWorkingDir: true
+## ExecRaw: true
+
+phpstan "$@"

--- a/assets/replace/.ddev/commands/web/phpunit
+++ b/assets/replace/.ddev/commands/web/phpunit
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+## Description: Run PHPUnit
+## Usage: phpunit [flags] [args]
+## Example: "ddev phpunit --testsuite=unit" or "ddev phpunit public/modules/custom/foobar"
+## HostWorkingDir: true
+## ExecRaw: true
+
+phpunit "$@"

--- a/assets/replace/.ddev/config.yaml.twig
+++ b/assets/replace/.ddev/config.yaml.twig
@@ -19,3 +19,5 @@ web_environment:
     - "DRUPAL_ENVIRONMENT=local"
     - SIMPLETEST_DB=$DDEV_DATABASE_FAMILY://db:db@db/db
     - SIMPLETEST_BASE_URL=$DDEV_PRIMARY_URL
+    - DTT_BASE_URL=$DDEV_PRIMARY_URL
+    - DTT_SCREENSHOT_REPORT_DIRECTORY=/var/www/html/app/public/sites/simpletest/browser_output

--- a/assets/replace/.ddev/config.yaml.twig
+++ b/assets/replace/.ddev/config.yaml.twig
@@ -16,7 +16,7 @@ composer_version: "2"
 corepack_enable: true
 ddev_version_constraint: '>= 1.24.0'
 web_environment:
-    - "DRUPAL_ENVIRONMENT=local"
+    - DRUPAL_ENVIRONMENT=local
     - SIMPLETEST_DB=$DDEV_DATABASE_FAMILY://db:db@db/db
     - SIMPLETEST_BASE_URL=$DDEV_PRIMARY_URL
     - DTT_BASE_URL=$DDEV_PRIMARY_URL

--- a/assets/replace/.ddev/config.yaml.twig
+++ b/assets/replace/.ddev/config.yaml.twig
@@ -17,3 +17,5 @@ corepack_enable: true
 ddev_version_constraint: '>= 1.24.0'
 web_environment:
     - "DRUPAL_ENVIRONMENT=local"
+    - SIMPLETEST_DB=$DDEV_DATABASE_FAMILY://db:db@db/db
+    - SIMPLETEST_BASE_URL=$DDEV_PRIMARY_URL

--- a/assets/replace/.github/actions/install-local/action.yml.twig
+++ b/assets/replace/.github/actions/install-local/action.yml.twig
@@ -3,13 +3,7 @@
 name: Install Drupal locally
 description: Checkout, configure, deploy and install a local drupal project
 inputs:
-  dockerhub_container_registry_user:
-    required: true
-  dockerhub_container_registry_password:
-    required: true
   ssh_key:
-    required: true
-  composer_auth:
     required: true
   caching:
     required: false
@@ -20,86 +14,33 @@ inputs:
 runs:
   using: composite
   steps:
-  - name: Import environment variables from a file
-    shell: bash
-    run: |
-      grep -v '^#' .env | grep . >> $GITHUB_ENV
-
   - name: Generate dynamic env variables
     shell: bash
     run: |
       echo "EXECUTION_DATE=$(date --rfc-3339=date)" >> $GITHUB_ENV
 
-  - name: Login to Docker Hub
-    uses: docker/login-action@v3
-    with:
-      username: ${{ inputs.dockerhub_container_registry_user }}
-      password: ${{ inputs.dockerhub_container_registry_password }}
+  - name: Setup DDEV
+    uses: ddev/github-action-setup-ddev@v1
 
-  - name: Cache Docker images
-    uses: ScribeMD/docker-cache@0.5.0
-    with:
-      key: ${{ runner.os }}-docker-${{ hashFiles('**/docker-compose.yml') }}
-
-  - name: Cache Composer dependency
-    if: ${{ inputs.caching == 'true' }}
-    id: cache-composer
-    uses: actions/cache@v4
-    with:
-      path: |
-        ./.composer
-      key: ${{ runner.os }}-build-drupal-composer-${{ hashFiles('**/composer.lock') }}
-
-  - name: Cache Drupal database
-    if: ${{ inputs.caching == 'true' }}
-    id: cache-db
-    uses: actions/cache@v4
-    with:
-      path: |
-        ./app/backups
-      key: ${{ runner.os }}-build-drupal-db-${{ inputs.caching_db_key }}
-
-  - name: Deploy local environment
+  - name: Setup SSH
     shell: bash
     env:
       SSH_KEY: ${{ inputs.ssh_key }}
-      COMPOSER_AUTH: ${{ inputs.composer_auth }}
     run: |
-      make deploy-local COMPOSE_FLAGS=-d
+      mkdir -p ~/.ssh
+      echo "$SSH_KEY" > ~/.ssh/id_rsa
+      chmod 600 ~/.ssh/id_rsa
+      ddev auth ssh -f ~/.ssh/id_rsa
 
-  - name: Restore composer dependency cache
-    if: ${{ inputs.caching == 'true' && steps.cache-composer.outputs.cache-hit == 'true' }}
+  - name: Deploy local environment
     shell: bash
     run: |
-      [ -d ".composer" ] && make cli-local COMMAND='cp -r .composer/. $$(composer config -d ./app cache-files-dir)'
+      make runtime
 
   - name: Install local environment
     if: ${{ inputs.caching != 'true' || steps.cache-db.outputs.cache-hit != 'true' }}
     shell: bash
     run: |
-      make cli-local COMMAND="make project COMPOSER_FLAGS=\"--ansi --no-interaction --no-progress\""
-
-  - name: Install local environment from backup
-    if: ${{ inputs.caching == 'true' && steps.cache-db.outputs.cache-hit == 'true' }}
-    shell: bash
-    run: |
-      [ "$(compgen -G "./app/backups/*.sql.gz" | wc -l)" -eq 0 ] && exit 1
-      cp ./app/backups/*.sql.gz ./app/resources
-      make cli-local COMMAND="make new COMPOSER_FLAGS=\"--ansi --no-interaction --no-progress\""
-      make cli-local COMMAND="drush cache:rebuild && drush deploy:hook"
-
-  - name: Create composer dependency cache
-    if: ${{ inputs.caching == 'true' && steps.cache-composer.outputs.cache-hit != 'true' }}
-    shell: bash
-    run: |
-        make cli-local COMMAND="mkdir -p .composer"
-        make cli-local COMMAND='cp -r $$(composer config -d ./app cache-files-dir)/. .composer'
-
-  - name: Create Drupal database cache
-    if: ${{ inputs.caching == 'true' && steps.cache-db.outputs.cache-hit != 'true' }}
-    shell: bash
-    run: |
-      make cli-local COMMAND="drush sql-sanitize -y"
-      make cli-local COMMAND="make db-backup"
+      make stack COMPOSER_FLAGS="--ansi --no-interaction --no-progress"
 {% endverbatim -%}
 {% endif %}

--- a/assets/replace/.github/actions/install-local/action.yml.twig
+++ b/assets/replace/.github/actions/install-local/action.yml.twig
@@ -20,6 +20,7 @@ runs:
       echo "EXECUTION_DATE=$(date --rfc-3339=date)" >> $GITHUB_ENV
 
   - name: Setup SSH key
+    shell: bash
     run: |
       mkdir -p .ddev/homeadditions/.ssh
       echo "${{ inputs.ssh_key }}" > .ddev/homeadditions/.ssh/id_rsa

--- a/assets/replace/.github/actions/install-local/action.yml.twig
+++ b/assets/replace/.github/actions/install-local/action.yml.twig
@@ -69,13 +69,13 @@ runs:
   - name: Install local environment
     shell: bash
     run: |
-      if [ "${{ inputs.caching }}" == "true" ] && [ "${{ steps.cache-db.outputs.cache-hit }}" == "false" ]; then
+      if [ "${{ inputs.caching }}" == "true" ] && [ "${{ steps.cache-db.outputs.cache-hit }}" != "true" ]; then
         export DRUPAL_NO_DEPLOY=true
       fi
       make stack COMPOSER_FLAGS="--ansi --no-interaction --no-progress"
 
   - name: Create Drupal database cache
-    if: ${{ inputs.caching == 'true' && steps.cache-db.outputs.cache-hit == 'false' }}
+    if: ${{ inputs.caching == 'true' && steps.cache-db.outputs.cache-hit != 'true' }}
     shell: bash
     run: |
       echo "Caching Drupal database..."

--- a/assets/replace/.github/actions/install-local/action.yml.twig
+++ b/assets/replace/.github/actions/install-local/action.yml.twig
@@ -8,7 +8,7 @@ inputs:
   caching:
     required: false
     default: false
-  caching_db_key:
+  cache_key:
     required: false
     default: "${{ github.sha }}"
 runs:
@@ -18,6 +18,33 @@ runs:
     shell: bash
     run: |
       echo "EXECUTION_DATE=$(date --rfc-3339=date)" >> $GITHUB_ENV
+
+  - name: Cache Composer dependency
+    id: cache-composer
+    uses: actions/cache@v4
+    with:
+      path: .composer
+      key: ${{ runner.os }}-build-drupal-composer-${{ hashFiles('**/composer.lock') }}
+
+  - name: Cache Drupal database
+    if: ${{ inputs.caching == 'true' }}
+    id: cache-db
+    uses: actions/cache@v4
+    with:
+      path: .ddev/db_snapshots
+      key: ${{ runner.os }}-build-drupal-db-${{ inputs.cache_key }}
+
+  - name: Setup CI DDEV config
+    shell: bash
+    run: |
+      cat <<EOF > .ddev/config.ci.yaml
+      web_environment:
+          - COMPOSER_NO_INTERACTION=1
+          - COMPOSER_DISCARD_CHANGES=1
+          - COMPOSER_FUND=0
+          - COMPOSER_NO_AUDIT=1
+          - COMPOSER_CACHE_DIR=.composer
+      EOF
 
   - name: Setup SSH key
     shell: bash
@@ -33,12 +60,28 @@ runs:
   - name: Deploy local environment
     shell: bash
     run: |
+      if [ "${{ inputs.caching }}" == "true" ] && [ "${{ steps.cache-db.outputs.cache-hit }}" == "true" ]; then
+        echo "Restoring Drupal database from cache..."
+        export DDEV_SNAPSHOT=ci
+      fi
       make runtime
 
   - name: Install local environment
-    if: ${{ inputs.caching != 'true' || steps.cache-db.outputs.cache-hit != 'true' }}
     shell: bash
     run: |
+      if [ "${{ inputs.caching }}" == "true" ] && [ "${{ steps.cache-db.outputs.cache-hit }}" == "false" ]; then
+        export DRUPAL_NO_DEPLOY=true
+      fi
       make stack COMPOSER_FLAGS="--ansi --no-interaction --no-progress"
+
+  - name: Create Drupal database cache
+    if: ${{ inputs.caching == 'true' && steps.cache-db.outputs.cache-hit == 'false' }}
+    shell: bash
+    run: |
+      echo "Caching Drupal database..."
+      ddev drush sql:sanitize -y
+      ddev snapshot --name ci
+      make drupal-deploy
+
 {% endverbatim -%}
 {% endif %}

--- a/assets/replace/.github/actions/install-local/action.yml.twig
+++ b/assets/replace/.github/actions/install-local/action.yml.twig
@@ -61,8 +61,10 @@ runs:
     shell: bash
     run: |
       if [ "${{ inputs.caching }}" == "true" ] && [ "${{ steps.cache-db.outputs.cache-hit }}" == "true" ]; then
-        echo "Restoring Drupal database from cache..."
-        export DDEV_SNAPSHOT=ci
+        if [ -f ".ddev/db_snapshots/ci-"* ]; then
+          echo "Restoring Drupal database from existing snapshot..."
+          export DDEV_SNAPSHOT=ci
+        fi
       fi
       make runtime
 

--- a/assets/replace/.github/actions/install-local/action.yml.twig
+++ b/assets/replace/.github/actions/install-local/action.yml.twig
@@ -43,7 +43,7 @@ runs:
           - COMPOSER_DISCARD_CHANGES=1
           - COMPOSER_FUND=0
           - COMPOSER_NO_AUDIT=1
-          - COMPOSER_CACHE_DIR=.composer
+          - COMPOSER_CACHE_DIR=/var/www/html/.composer
       EOF
 
   - name: Setup SSH key

--- a/assets/replace/.github/actions/install-local/action.yml.twig
+++ b/assets/replace/.github/actions/install-local/action.yml.twig
@@ -19,18 +19,15 @@ runs:
     run: |
       echo "EXECUTION_DATE=$(date --rfc-3339=date)" >> $GITHUB_ENV
 
+  - name: Setup SSH key
+    run: |
+      mkdir -p .ddev/homeadditions/.ssh
+      echo "${{ inputs.ssh_key }}" > .ddev/homeadditions/.ssh/id_rsa
+      chmod 700 .ddev/homeadditions/.ssh
+      chmod 600 .ddev/homeadditions/.ssh/id_rsa
+
   - name: Setup DDEV
     uses: ddev/github-action-setup-ddev@v1
-
-  - name: Setup SSH
-    shell: bash
-    env:
-      SSH_KEY: ${{ inputs.ssh_key }}
-    run: |
-      mkdir -p ~/.ssh
-      echo "$SSH_KEY" > ~/.ssh/id_rsa
-      chmod 600 ~/.ssh/id_rsa
-      ddev auth ssh -f ~/.ssh/id_rsa
 
   - name: Deploy local environment
     shell: bash

--- a/assets/replace/.github/actions/upgrade/upgrade.sh
+++ b/assets/replace/.github/actions/upgrade/upgrade.sh
@@ -54,11 +54,17 @@ if [[ -n "$RSH" && "$RSH" == "make-cli" ]]; then
   echo "Using remote shell: make cli"
 fi
 
+if [[ -n "$RSH" && "$RSH" == "ddev" ]]; then
+  echo "Using remote shell: ddev"
+fi
+
 function rsh {
   echo "$@"
   if [[ -n "$RSH" && "$RSH" == "make-cli" ]]; then
     # Make sure the arguments' value is quoted in a format that can be reused as input.
     COMMAND="${*@Q}" make cli
+  elif [[ -n "$RSH" && "$RSH" == "ddev" ]]; then
+    ddev exec -- "${*@Q}"
   else
     eval "${*@Q}"
   fi

--- a/assets/replace/.github/workflows/phpcs.yml.twig
+++ b/assets/replace/.github/workflows/phpcs.yml.twig
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: "Set up PHP"
       uses: shivammathur/setup-php@v2
@@ -33,14 +33,12 @@ jobs:
       shell: bash
       run: |
         echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-        COMPOSER_AUTH="${{ secrets.COMPOSER_AUTH }}"
-        echo "COMPOSER_AUTH=$COMPOSER_AUTH" >> $GITHUB_ENV
-        echo "::add-mask::$COMPOSER_AUTH"
+        echo "REPO_CODE=$(git ls-tree -d -r $(git write-tree) --name-only | grep -E '(themes|modules)/custom/[^/]+$$' | paste -s -)" >> $GITHUB_ENV
 
     - name: "Run PHP parallel lint"
       shell: bash
       run: |
-        make phplint PARALINT_FLAGS="--no-progress"
+        parallel-lint ${REPO_CODE} -e php,module,theme,inc,install,profile --no-progress
 
     - name: "Install dependencies"
       shell: bash
@@ -51,7 +49,13 @@ jobs:
     - name: "Run PHPCS"
       shell: bash
       run: |
-        make phpcs APP_ROOT="${{ github.workspace }}/app" PHPCS_FLAGS="-q --report=checkstyle" \
+        phpcs \
+          --standard=./app/phpcs.xml.dist \
+          --runtime-set ignore_warnings_on_exit 1 \
+          --report=checkstyle \
+          --quiet \
+          ${REPO_CODE} \
           | cs2pr --graceful-warnings
+
 {% endverbatim -%}
 {% endif %}

--- a/assets/replace/.github/workflows/phpcs.yml.twig
+++ b/assets/replace/.github/workflows/phpcs.yml.twig
@@ -53,7 +53,7 @@ jobs:
           --standard=./app/phpcs.xml.dist \
           --runtime-set ignore_warnings_on_exit 1 \
           --report=checkstyle \
-          --quiet \
+          -q \
           ${REPO_CODE} \
           | cs2pr --graceful-warnings
 

--- a/assets/replace/.github/workflows/phpunit-functional-testing.yml.twig
+++ b/assets/replace/.github/workflows/phpunit-functional-testing.yml.twig
@@ -1,10 +1,6 @@
 {% if workflows.phpunit %}
 name: PHPUnit functional testing
 
-env:
-  DOCKER_WEB_PORT: 80:80
-  DOCKER_WEB_NETWORK: {{ project_name|default(name ~ '-sw-project') }}_default
-
 {% verbatim -%}
 on:
   workflow_dispatch:
@@ -43,24 +39,19 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install Drupal locally
       uses: ./.github/actions/install-local
       with:
-        dockerhub_container_registry_user: ${{ secrets.DOCKERHUB_CONTAINER_REGISTRY_USER }}
-        dockerhub_container_registry_password: ${{ secrets.DOCKERHUB_CONTAINER_REGISTRY_PASSWORD }}
         ssh_key: ${{ secrets.SSH_KEY }}
-        composer_auth: ${{ secrets.COMPOSER_AUTH }}
         caching: true
         caching_db_key: ${{ inputs.database-cache-key }}
 
     - name: Run PHPUnit database tests
       shell: bash
       run: |
-        curl --fail --retry 3 --retry-delay 10 -Lso /dev/null http://localhost || \
-          (echo 'Accessing homepage of Drupal site failed.' && exit 1)
-        make cli-local COMMAND='make phpunit-db PHPUNIT_FLAGS="--log-junit TEST-phpunit.xml"'
+        make drupal-test-db PHPUNIT_FLAGS="--log-junit TEST-phpunit.xml"
 
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v4
@@ -68,7 +59,7 @@ jobs:
       with:
         report_paths: '**/TEST-*.xml'
         check_name: "PHPUnit database report"
-        transformers: '[{"searchValue":"project/","replaceValue":""}]'
+        transformers: '[{"searchValue":"var/www/html/","replaceValue":""}]'
         annotate_only: true
 
     - name: Upload HTML output
@@ -92,25 +83,19 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install Drupal locally
       uses: ./.github/actions/install-local
       with:
-        dockerhub_container_registry_user: ${{ secrets.DOCKERHUB_CONTAINER_REGISTRY_USER }}
-        dockerhub_container_registry_password: ${{ secrets.DOCKERHUB_CONTAINER_REGISTRY_PASSWORD }}
         ssh_key: ${{ secrets.SSH_KEY }}
-        composer_auth: ${{ secrets.COMPOSER_AUTH }}
         caching: true
         caching_db_key: ${{ inputs.database-cache-key }}
 
     - name: Run PHPUnit browser tests
       shell: bash
       run: |
-        curl --fail --retry 3 --retry-delay 10 -Lso /dev/null http://localhost || \
-          (echo 'Accessing homepage of Drupal site failed.' && exit 1)
-        docker network connect ${{ env.DOCKER_WEB_NETWORK }} --alias chrome ${{ job.services.chrome.id }}
-        make cli-local COMMAND='make phpunit-browser PHPUNIT_FLAGS="--log-junit TEST-phpunit.xml"'
+        make drupal-test-browser PHPUNIT_FLAGS="--log-junit TEST-phpunit.xml"
 
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v4
@@ -118,7 +103,7 @@ jobs:
       with:
         report_paths: '**/TEST-*.xml'
         check_name: "PHPUnit browser report"
-        transformers: '[{"searchValue":"project/","replaceValue":""}]'
+        transformers: '[{"searchValue":"var/www/html/","replaceValue":""}]'
         annotate_only: true
 
     - name: Upload HTML output

--- a/assets/replace/.github/workflows/phpunit-functional-testing.yml.twig
+++ b/assets/replace/.github/workflows/phpunit-functional-testing.yml.twig
@@ -23,7 +23,7 @@ on:
         default: true
         required: true
         type: boolean
-      database-cache-key:
+      cache_key:
         default: "${{ github.sha }}"
         type: string
 
@@ -46,7 +46,7 @@ jobs:
       with:
         ssh_key: ${{ secrets.SSH_KEY }}
         caching: true
-        caching_db_key: ${{ inputs.database-cache-key }}
+        cache_key: ${{ inputs.cache_key }}
 
     - name: Run PHPUnit database tests
       shell: bash
@@ -83,7 +83,7 @@ jobs:
       with:
         ssh_key: ${{ secrets.SSH_KEY }}
         caching: true
-        caching_db_key: ${{ inputs.database-cache-key }}
+        cache_key: ${{ inputs.cache_key }}
 
     - name: Enable Chrome tooling
       shell: bash

--- a/assets/replace/.github/workflows/phpunit-functional-testing.yml.twig
+++ b/assets/replace/.github/workflows/phpunit-functional-testing.yml.twig
@@ -74,13 +74,6 @@ jobs:
     if: ${{ inputs.browser-testing || (inputs.testing-type && inputs.testing-type == 'browser') }}
     runs-on: ubuntu-latest
 
-    services:
-      chrome:
-        image: selenium/standalone-chrome:106.0
-        options: >-
-          --env SE_NODE_SESSION_TIMEOUT=700
-          --shm-size=2g
-
     steps:
     - name: Checkout
       uses: actions/checkout@v5
@@ -91,6 +84,11 @@ jobs:
         ssh_key: ${{ secrets.SSH_KEY }}
         caching: true
         caching_db_key: ${{ inputs.database-cache-key }}
+
+    - name: Enable Chrome tooling
+      shell: bash
+      run: |
+        make tool-chrome
 
     - name: Run PHPUnit browser tests
       shell: bash

--- a/assets/replace/.github/workflows/phpunit-functional-testing.yml.twig
+++ b/assets/replace/.github/workflows/phpunit-functional-testing.yml.twig
@@ -54,7 +54,7 @@ jobs:
         make drupal-test-db PHPUNIT_FLAGS="--log-junit TEST-phpunit.xml"
 
     - name: Publish Test Report
-      uses: mikepenz/action-junit-report@v4
+      uses: mikepenz/action-junit-report@v6
       if: success() || failure()
       with:
         report_paths: '**/TEST-*.xml'
@@ -64,7 +64,7 @@ jobs:
 
     - name: Upload HTML output
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: phpunit-db-report
         path: ./app/public/sites/simpletest/browser_output
@@ -96,7 +96,7 @@ jobs:
         make drupal-test-browser PHPUNIT_FLAGS="--log-junit TEST-phpunit.xml"
 
     - name: Publish Test Report
-      uses: mikepenz/action-junit-report@v4
+      uses: mikepenz/action-junit-report@v6
       if: success() || failure()
       with:
         report_paths: '**/TEST-*.xml'
@@ -106,7 +106,7 @@ jobs:
 
     - name: Upload HTML output
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: phpunit-browser-report
         path: ./app/public/sites/simpletest/browser_output

--- a/assets/replace/.github/workflows/phpunit-unit-testing.yml.twig
+++ b/assets/replace/.github/workflows/phpunit-unit-testing.yml.twig
@@ -32,9 +32,6 @@ jobs:
       shell: bash
       run: |
         echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-        COMPOSER_AUTH="${{ secrets.COMPOSER_AUTH }}"
-        echo "COMPOSER_AUTH=$COMPOSER_AUTH" >> $GITHUB_ENV
-        echo "::add-mask::$COMPOSER_AUTH"
 
     - name: "Install dependencies"
       shell: bash
@@ -45,7 +42,7 @@ jobs:
     - name: "Run PHPUnit Unit Tests"
       shell: bash
       run: |
-        make phpunit PHPUNIT_CONFIG="${{ github.workspace }}/app" APP_ROOT="${{ github.workspace }}/app" PHPUNIT_FLAGS="--log-junit TEST-phpunit.xml"
+        phpunit -c ./app --testsuite=unit --log-junit TEST-phpunit.xml
 
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v4

--- a/assets/replace/.github/workflows/phpunit-unit-testing.yml.twig
+++ b/assets/replace/.github/workflows/phpunit-unit-testing.yml.twig
@@ -45,7 +45,7 @@ jobs:
         phpunit -c ./app --testsuite=unit --log-junit TEST-phpunit.xml
 
     - name: Publish Test Report
-      uses: mikepenz/action-junit-report@v4
+      uses: mikepenz/action-junit-report@v6
       if: success() || failure()
       with:
         report_paths: '**/TEST-*.xml'

--- a/assets/replace/.github/workflows/testing.yml.twig
+++ b/assets/replace/.github/workflows/testing.yml.twig
@@ -2,9 +2,6 @@
 {%- verbatim -%}
 name: Drupal testing
 
-env:
-  DOCKER_WEB_PORT: 80:80
-
 on:
   workflow_dispatch:
   pull_request:
@@ -25,15 +22,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install Drupal locally
       uses: ./.github/actions/install-local
       with:
-        dockerhub_container_registry_user: ${{ secrets.DOCKERHUB_CONTAINER_REGISTRY_USER }}
-        dockerhub_container_registry_password: ${{ secrets.DOCKERHUB_CONTAINER_REGISTRY_PASSWORD }}
         ssh_key: ${{ secrets.SSH_KEY }}
-        composer_auth: ${{ secrets.COMPOSER_AUTH }}
         caching: true
         caching_db_key: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -42,7 +36,7 @@ jobs:
       shell: bash
       run: |
         PHPUNIT_TESTS_LIST="${{ runner.temp }}/phpunit-tests.txt"
-        make cli-local COMMAND="cd ./app && phpunit --list-tests" | tee $PHPUNIT_TESTS_LIST
+        make drupal-test-list | tee $PHPUNIT_TESTS_LIST
         if grep -q '\\ExistingSiteJavascript\\' $PHPUNIT_TESTS_LIST; then
           echo "browser_testing=true" >> $GITHUB_OUTPUT
         fi
@@ -62,13 +56,13 @@ jobs:
     - name: Detect missing config in repository
       shell: bash
       run: |
-        make cli-local COMMAND="drush --no config:export --diff" || \
+        ddev drush --no config:export --diff || \
           (echo 'There is missing configuration that has not been exported to the repository.' && exit 1)
 
     - name: Validate composer lock file
       shell: bash
       run: |
-        composer validate -d ./app --ansi
+        make drupal-validate
 
   lint:
     name: "PHPCS"

--- a/assets/replace/.github/workflows/testing.yml.twig
+++ b/assets/replace/.github/workflows/testing.yml.twig
@@ -29,7 +29,7 @@ jobs:
       with:
         ssh_key: ${{ secrets.SSH_KEY }}
         caching: true
-        caching_db_key: ${{ github.event.pull_request.head.sha || github.sha }}
+        cache_key: ${{ github.event.pull_request.head.sha || github.sha }}
 
     - name: Detect available tests
       id: phpunit-tests
@@ -82,7 +82,7 @@ jobs:
     with:
       database-testing: ${{ needs.build.outputs.browser_testing == 'true'}}
       browser-testing: ${{ needs.build.outputs.database_testing == 'true'}}
-      database-cache-key: ${{ github.event.pull_request.head.sha || github.sha }}
+      cache_key: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit
 
   visual-regression-tests:
@@ -90,7 +90,7 @@ jobs:
     uses: ./.github/workflows/visual-regression-testing.yml
     needs: [build]
     with:
-      database-cache-key: ${{ github.event.pull_request.head.sha || github.sha }}
+      cache_key: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit
 {% endverbatim -%}
 {% endif %}

--- a/assets/replace/.github/workflows/update.yml.twig
+++ b/assets/replace/.github/workflows/update.yml.twig
@@ -30,6 +30,9 @@ jobs:
       shell: bash
       run: |
         make update COMPOSER_FLAGS=-n DRUSH_FLAGS=-y
+        if [ -f .ddev/homeadditions/.ssh/id_rsa ]; then
+          rm .ddev/homeadditions/.ssh/id_rsa
+        fi
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v7

--- a/assets/replace/.github/workflows/update.yml.twig
+++ b/assets/replace/.github/workflows/update.yml.twig
@@ -19,23 +19,20 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install Drupal locally
       uses: ./.github/actions/install-local
       with:
-        dockerhub_container_registry_user: ${{ secrets.DOCKERHUB_CONTAINER_REGISTRY_USER }}
-        dockerhub_container_registry_password: ${{ secrets.DOCKERHUB_CONTAINER_REGISTRY_PASSWORD }}
         ssh_key: ${{ secrets.SSH_KEY }}
-        composer_auth: ${{ secrets.COMPOSER_AUTH }}
 
     - name: Run Drupal updates
       shell: bash
       run: |
-        make cli-local COMMAND="make update COMPOSER_FLAGS=-n DRUSH_FLAGS=-y"
+        make update COMPOSER_FLAGS=-n DRUSH_FLAGS=-y
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@v7
       with:
         token: ${{ github.event.inputs.token || secrets.GITHUB_TOKEN }}
         commit-message: Updated Drupal site

--- a/assets/replace/.github/workflows/upgrade.yml.twig
+++ b/assets/replace/.github/workflows/upgrade.yml.twig
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Generate Input
       shell: bash
@@ -91,21 +91,17 @@ jobs:
     - name: Install Drupal locally
       uses: ./.github/actions/install-local
       with:
-        dockerhub_container_registry_user: ${{ secrets.DOCKERHUB_CONTAINER_REGISTRY_USER }}
-        dockerhub_container_registry_password: ${{ secrets.DOCKERHUB_CONTAINER_REGISTRY_PASSWORD }}
         ssh_key: ${{ secrets.SSH_KEY }}
-        composer_auth: ${{ secrets.COMPOSER_AUTH }}
 
     - name: Run Drupal upgrades script
       shell: bash
       env:
-        RSH: "make-cli"
-        COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
+        RSH: "ddev"
       run: |
         make upgrade
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@v7
       with:
         token: ${{ github.event.inputs.token || secrets.GITHUB_TOKEN }}
         commit-message: Upgraded Drupal site

--- a/assets/replace/.github/workflows/upgrade.yml.twig
+++ b/assets/replace/.github/workflows/upgrade.yml.twig
@@ -99,6 +99,9 @@ jobs:
         RSH: "ddev"
       run: |
         make upgrade
+        if [ -f .ddev/homeadditions/.ssh/id_rsa ]; then
+          rm .ddev/homeadditions/.ssh/id_rsa
+        fi
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v7

--- a/assets/replace/.github/workflows/visual-regression-testing.yml.twig
+++ b/assets/replace/.github/workflows/visual-regression-testing.yml.twig
@@ -1,9 +1,6 @@
 {% if workflows.vrt %}
 name: Visual Regression testing
 
-env:
-  DOCKER_WEB_PORT: 80:80
-
 {% if workflows.phpunit %}
 {% verbatim -%}
 on:
@@ -21,15 +18,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install Drupal locally
       uses: ./.github/actions/install-local
       with:
-        dockerhub_container_registry_user: ${{ secrets.DOCKERHUB_CONTAINER_REGISTRY_USER }}
-        dockerhub_container_registry_password: ${{ secrets.DOCKERHUB_CONTAINER_REGISTRY_PASSWORD }}
         ssh_key: ${{ secrets.SSH_KEY }}
-        composer_auth: ${{ secrets.COMPOSER_AUTH }}
         caching: true
         caching_db_key: ${{ inputs.database-cache-key || github.sha }}
 
@@ -50,15 +44,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install Drupal locally
       uses: ./.github/actions/install-local
       with:
-        dockerhub_container_registry_user: ${{ secrets.DOCKERHUB_CONTAINER_REGISTRY_USER }}
-        dockerhub_container_registry_password: ${{ secrets.DOCKERHUB_CONTAINER_REGISTRY_PASSWORD }}
         ssh_key: ${{ secrets.SSH_KEY }}
-        composer_auth: ${{ secrets.COMPOSER_AUTH }}
 
     - name: Run Visual regression tests
       uses: ./app/vendor/iqual-ch/ci-pocketknife-installer/.github/actions/visual-regression-tests

--- a/assets/replace/.github/workflows/visual-regression-testing.yml.twig
+++ b/assets/replace/.github/workflows/visual-regression-testing.yml.twig
@@ -32,7 +32,6 @@ jobs:
       with:
         path: playwright-snapshots
         key: vrt-baseline-${{ inputs.cache_key || github.sha }}-${{ hashFiles('playwright-vrt.config.json') }}
-        restore-keys: vrt-baseline-
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v1
@@ -82,7 +81,6 @@ jobs:
       with:
         path: playwright-snapshots
         key: vrt-baseline-${{ github.sha }}-${{ hashFiles('playwright-vrt.config.json') }}
-        restore-keys: vrt-baseline-
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v1

--- a/assets/replace/.github/workflows/visual-regression-testing.yml.twig
+++ b/assets/replace/.github/workflows/visual-regression-testing.yml.twig
@@ -50,7 +50,7 @@ jobs:
           --verbose
 
     - name: Upload VRT report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       if: always()
       with:
         name: vrt-report
@@ -100,7 +100,7 @@ jobs:
           --verbose
 
     - name: Upload VRT report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       if: always()
       with:
         name: vrt-report

--- a/assets/replace/.github/workflows/visual-regression-testing.yml.twig
+++ b/assets/replace/.github/workflows/visual-regression-testing.yml.twig
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
-      database-cache-key:
+      cache_key:
         default: "${{ github.sha }}"
         type: string
 
@@ -25,7 +25,14 @@ jobs:
       with:
         ssh_key: ${{ secrets.SSH_KEY }}
         caching: true
-        caching_db_key: ${{ inputs.database-cache-key || github.sha }}
+        cache_key: ${{ inputs.cache_key || github.sha }}
+
+    - name: Restore VRT baseline cache
+      uses: actions/cache@v4
+      with:
+        path: playwright-snapshots
+        key: vrt-baseline-${{ inputs.cache_key || github.sha }}-${{ hashFiles('playwright-vrt.config.json') }}
+        restore-keys: vrt-baseline-
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v1
@@ -69,6 +76,13 @@ jobs:
       uses: ./.github/actions/install-local
       with:
         ssh_key: ${{ secrets.SSH_KEY }}
+
+    - name: Restore VRT baseline cache
+      uses: actions/cache@v4
+      with:
+        path: playwright-snapshots
+        key: vrt-baseline-${{ github.sha }}-${{ hashFiles('playwright-vrt.config.json') }}
+        restore-keys: vrt-baseline-
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v1

--- a/assets/replace/.github/workflows/visual-regression-testing.yml.twig
+++ b/assets/replace/.github/workflows/visual-regression-testing.yml.twig
@@ -27,8 +27,27 @@ jobs:
         caching: true
         caching_db_key: ${{ inputs.database-cache-key || github.sha }}
 
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v1
+
+    - name: Install Playwright VRT dependencies
+      shell: bash
+      run: |
+        bunx playwright install chromium
+
     - name: Run Visual regression tests
-      uses: ./app/vendor/iqual-ch/ci-pocketknife-installer/.github/actions/visual-regression-tests
+      shell: bash
+      run: |
+        bunx @iqual/playwright-vrt run \
+          --config playwright-vrt.config.json \
+          --verbose
+
+    - name: Upload VRT report
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: vrt-report
+        path: playwright-report/
 {% endverbatim -%}
 {% else %}
 {% verbatim -%}
@@ -51,8 +70,27 @@ jobs:
       with:
         ssh_key: ${{ secrets.SSH_KEY }}
 
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v1
+
+    - name: Install Playwright VRT dependencies
+      shell: bash
+      run: |
+        bunx playwright install chromium
+
     - name: Run Visual regression tests
-      uses: ./app/vendor/iqual-ch/ci-pocketknife-installer/.github/actions/visual-regression-tests
+      shell: bash
+      run: |
+        bunx @iqual/playwright-vrt run \
+          --config playwright-vrt.config.json \
+          --verbose
+
+    - name: Upload VRT report
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: vrt-report
+        path: playwright-report/
 {% endverbatim -%}
 {% endif %}
 {% endif %}

--- a/assets/replace/.vscode/settings.json.twig
+++ b/assets/replace/.vscode/settings.json.twig
@@ -42,9 +42,11 @@
   "php.suggest.basic": false,
 
   /* PHP Sniffer & Beautifier settings */
-  "phpsab.standard": "Drupal,DrupalPractice",
-  "phpsab.executablePathCS": "app/vendor/bin/ddev-shim-phpcs-ext",
-  "phpsab.executablePathCBF": "app/vendor/bin/ddev-shim-phpcbf-ext",
+  "phpsab.standard": "app/phpcs.xml.dist",
+  "phpsab.autoRulesetSearch": false,
+  "phpsab.composerJsonPath": "app/composer.json",
+  "phpsab.executablePathCS": "app/vendor/bin/ddev-shim-phpcs",
+  "phpsab.executablePathCBF": "app/vendor/bin/ddev-shim-phpcbf",
   "phpsab.snifferMode": "onType",
   "[php]": {
     "editor.defaultFormatter": "valeryanm.vscode-phpsab"

--- a/assets/replace/@app-root/phpcs.xml.dist
+++ b/assets/replace/@app-root/phpcs.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset name="Drupal Platform Coding Standards">
+  <rule ref="Drupal">
+  </rule>
+  <rule ref="DrupalPractice"/>
+  <file>./public/modules/custom/</file>
+  <file>./public/themes/custom/</file>
+  <exclude-pattern>*/.git/*</exclude-pattern>
+  <exclude-pattern>*/config/*</exclude-pattern>
+  <exclude-pattern>*/css/*</exclude-pattern>
+  <exclude-pattern>*/js/*</exclude-pattern>
+  <exclude-pattern>*/icons/*</exclude-pattern>
+  <exclude-pattern>*/vendor/*</exclude-pattern>
+  <exclude-pattern>*/node_modules/*</exclude-pattern>
+  <exclude-pattern>*rules_export.txt</exclude-pattern>
+  <arg name="extensions" value="engine,inc,info,install,module,php,profile,test,theme,yml" />
+</ruleset>

--- a/assets/replace/@app-root/phpstan.neon
+++ b/assets/replace/@app-root/phpstan.neon
@@ -1,0 +1,20 @@
+parameters:
+  level: 5
+  paths:
+    - %currentWorkingDirectory%/public/modules/custom
+    - %currentWorkingDirectory%/public/themes/custom
+  excludePaths:
+    - *node_modules/*
+    - *.twig
+  fileExtensions:
+    - php
+    - module
+    - inc
+    - install
+    - test
+    - profile
+    - theme
+  reportUnmatchedIgnoredErrors: false
+  ignoreErrors:
+    - '#^Unsafe usage of new static#'
+  treatPhpDocTypesAsCertain: false

--- a/assets/replace/@app-root/phpunit.xml.dist
+++ b/assets/replace/@app-root/phpunit.xml.dist
@@ -5,29 +5,8 @@
     <ini name="error_reporting" value="32767"/>
     <!-- Do not limit the amount of memory tests take to run. -->
     <ini name="memory_limit" value="-1"/>
-    <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
-    <env name="SIMPLETEST_BASE_URL" value="http://web"/>
-    <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
-    <env name="SIMPLETEST_DB" value="mysql://drupal:drupal@db/drupal"/>
-    <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
-    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/tmp"/>
-    <!-- To have browsertest output use an alternative base URL. For example if
-     SIMPLETEST_BASE_URL is an internal DDEV URL, you can set this to the
-     external DDev URL so you can follow the links directly.
-    -->
-    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
-    <env name="DTT_BASE_URL" value="http://web"/>
-    <!-- Specify the default directory screenshots should be placed. -->
-    <env name="DTT_SCREENSHOT_REPORT_DIRECTORY" value="/project/app/public/sites/simpletest/browser_output"/>
-    <env name="DTT_MINK_DRIVER_ARGS" value="[&quot;chrome&quot;, { &quot;chromeOptions&quot; : { &quot;w3c&quot;: false } }, &quot;http://chrome:4444/wd/hub&quot;]"/>
     <!-- To disable deprecation testing completely uncomment the next line. -->
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
-    <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
-    <env name="MINK_DRIVER_CLASS" value=""/>
-    <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
-    <env name="MINK_DRIVER_ARGS" value=""/>
-    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
-    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value="[&quot;chrome&quot;, { &quot;chromeOptions&quot; : { &quot;w3c&quot;: false } }, &quot;http://chrome:4444/wd/hub&quot;]"/>
   </php>
   <testsuites>
     <testsuite name="app">

--- a/assets/replace/@app-root/phpunit.xml.dist
+++ b/assets/replace/@app-root/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/weitzman/drupal-test-traits/src/bootstrap.php" colors="true" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutOutputDuringTests="true" beStrictAboutChangesToGlobalState="true" failOnWarning="true" printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter" cacheResult="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/weitzman/drupal-test-traits/src/bootstrap.php" colors="true" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutOutputDuringTests="true" beStrictAboutChangesToGlobalState="true" failOnWarning="true" cacheResult="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <php>
     <!-- Set error reporting to E_ALL. -->
     <ini name="error_reporting" value="32767"/>
@@ -19,7 +19,7 @@
     <env name="DTT_BASE_URL" value="http://web"/>
     <!-- Specify the default directory screenshots should be placed. -->
     <env name="DTT_SCREENSHOT_REPORT_DIRECTORY" value="/project/app/public/sites/simpletest/browser_output"/>
-    <env name="DTT_MINK_DRIVER_ARGS" value='["chrome", { "chromeOptions" : { "w3c": false } }, "http://chrome:4444/wd/hub"]'/>
+    <env name="DTT_MINK_DRIVER_ARGS" value="[&quot;chrome&quot;, { &quot;chromeOptions&quot; : { &quot;w3c&quot;: false } }, &quot;http://chrome:4444/wd/hub&quot;]"/>
     <!-- To disable deprecation testing completely uncomment the next line. -->
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
     <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
@@ -27,41 +27,41 @@
     <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
     <env name="MINK_DRIVER_ARGS" value=""/>
     <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
-    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", { "chromeOptions" : { "w3c": false } }, "http://chrome:4444/wd/hub"]'/>
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value="[&quot;chrome&quot;, { &quot;chromeOptions&quot; : { &quot;w3c&quot;: false } }, &quot;http://chrome:4444/wd/hub&quot;]"/>
   </php>
   <testsuites>
-      <testsuite name="app">
-          <directory>./test*/src</directory>
-      </testsuite>
-      <testsuite name="unit">
-          <directory>./test*/src/Unit</directory>
-          <directory>./public/modules/custom/*/tests/src/Unit</directory>
-          <directory>./vendor/iqual/*-test-suite/tests/src/Unit</directory>
-      </testsuite>
-      <testsuite name="kernel">
-          <directory>./test*/src/Kernel</directory>
-          <directory>./public/modules/custom/*/tests/src/Kernel</directory>
-          <directory>./vendor/iqual/*-test-suite/tests/src/Kernel</directory>
-      </testsuite>
-      <testsuite name="functional">
-          <directory>./test*/src/Functional</directory>
-          <directory>./public/modules/custom/*/tests/src/Functional</directory>
-          <directory>./vendor/iqual/*-test-suite/tests/src/Functional</directory>
-      </testsuite>
-      <testsuite name="functional-javascript">
-          <directory>./test*/src/FunctionalJavascript</directory>
-          <directory>./public/modules/custom/*/tests/src/FunctionalJavascript</directory>
-          <directory>./vendor/iqual/*-test-suite/tests/src/FunctionalJavascript</directory>
-      </testsuite>
-      <testsuite name="existingsite">
-          <directory>./test*/src/ExistingSite</directory>
-          <directory>./public/modules/custom/*/tests/src/ExistingSite</directory>
-          <directory>./vendor/iqual/*-test-suite/tests/src/ExistingSite</directory>
-      </testsuite>
-      <testsuite name="existingsite-javascript">
-          <directory>./test*/src/ExistingSiteJavascript</directory>
-          <directory>./public/modules/custom/*/tests/src/ExistingSiteJavascript</directory>
-          <directory>./vendor/iqual/*-test-suite/tests/src/ExistingSiteJavascript</directory>
-      </testsuite>
+    <testsuite name="app">
+      <directory>./test*/src</directory>
+    </testsuite>
+    <testsuite name="unit">
+      <directory>./test*/src/Unit</directory>
+      <directory>./public/modules/custom/*/tests/src/Unit</directory>
+      <directory>./vendor/iqual/*-test-suite/tests/src/Unit</directory>
+    </testsuite>
+    <testsuite name="kernel">
+      <directory>./test*/src/Kernel</directory>
+      <directory>./public/modules/custom/*/tests/src/Kernel</directory>
+      <directory>./vendor/iqual/*-test-suite/tests/src/Kernel</directory>
+    </testsuite>
+    <testsuite name="functional">
+      <directory>./test*/src/Functional</directory>
+      <directory>./public/modules/custom/*/tests/src/Functional</directory>
+      <directory>./vendor/iqual/*-test-suite/tests/src/Functional</directory>
+    </testsuite>
+    <testsuite name="functional-javascript">
+      <directory>./test*/src/FunctionalJavascript</directory>
+      <directory>./public/modules/custom/*/tests/src/FunctionalJavascript</directory>
+      <directory>./vendor/iqual/*-test-suite/tests/src/FunctionalJavascript</directory>
+    </testsuite>
+    <testsuite name="existingsite">
+      <directory>./test*/src/ExistingSite</directory>
+      <directory>./public/modules/custom/*/tests/src/ExistingSite</directory>
+      <directory>./vendor/iqual/*-test-suite/tests/src/ExistingSite</directory>
+    </testsuite>
+    <testsuite name="existingsite-javascript">
+      <directory>./test*/src/ExistingSiteJavascript</directory>
+      <directory>./public/modules/custom/*/tests/src/ExistingSiteJavascript</directory>
+      <directory>./vendor/iqual/*-test-suite/tests/src/ExistingSiteJavascript</directory>
+    </testsuite>
   </testsuites>
 </phpunit>

--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -29,7 +29,7 @@ help: ## Show this help message
 	}
 	/^[0-9A-Za-z_.-]+:.*?##/ {
 		# Print a target line with its description
-		printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2
+		printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2
 	}' $(MAKEFILE_LIST)
 	echo -e "\n\033[1mQuick start\033[0m: make \033[36minstall\033[0m"
 
@@ -38,10 +38,10 @@ quickhelp:
 	echo -e "\033[1mUsage\033[0m: make \033[36m[target]\033[0m"
 	echo -e "\033[1mQuick Start\033[0m: make \033[36minstall\033[0m\n"
 	echo -e "Essential Commands:"
-	echo -e "  \033[36minstall\033[0m      Setup and install the project"
-	echo -e "  \033[36mlaunch\033[0m       Open project in browser"
-	echo -e "  \033[36mcode\033[0m         Start coding in VS Code"
-	echo -e "  \033[36mhelp\033[0m         Show all available commands"
+	echo -e "  \033[36minstall\033[0m          Setup and install the project"
+	echo -e "  \033[36mlaunch\033[0m           Open project in browser"
+	echo -e "  \033[36mcode\033[0m             Start coding in VS Code"
+	echo -e "  \033[36mhelp\033[0m             Show all available commands"
 
 .DEFAULT_GOAL := quickhelp
 
@@ -185,6 +185,11 @@ drupal-test-list: ## List Drupal tests
 drupal-test-unit: ## Run Drupal unit tests
 	@echo -e " $(MSG_INFO) Testing Drupal"
 	ddev phpunit -c ./app --testsuite=unit $(PHPUNIT_FLAGS)
+
+drupal-test-func: ## Run Drupal functional tests
+	@echo -e " $(MSG_INFO) Running functional tests"
+	echo -e " $(MSG_WARNING) Some tests could modify your existing database."
+	ddev phpunit -c ./app --testsuite=unit,kernel,functional,functional-javascript $(PHPUNIT_FLAGS)
 
 drupal-test-db: ## Run Drupal db tests
 	@echo -e " $(MSG_INFO) Running database tests"

--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -78,7 +78,7 @@ runtime: ## Start local runtime
 	@echo -e " $(MSG_INFO) Starting DDEV runtimes"
 	ddev start
 	if [ -n "$(DDEV_SNAPSHOT)" ]; then
-    echo -e " $(MSG_INFO) Restoring Drupal snapshot: $(DDEV_SNAPSHOT)"
+		echo -e " $(MSG_INFO) Restoring Drupal snapshot: $(DDEV_SNAPSHOT)"
 		if [ "$(DDEV_SNAPSHOT)" = "latest" ]; then
 			ddev snapshot restore --latest
 		else

--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -78,6 +78,7 @@ runtime: ## Start local runtime
 	@echo -e " $(MSG_INFO) Starting DDEV runtimes"
 	ddev start
 	if [ -n "$(DDEV_SNAPSHOT)" ]; then
+    echo -e " $(MSG_INFO) Restoring Drupal snapshot: $(DDEV_SNAPSHOT)"
 		if [ "$(DDEV_SNAPSHOT)" = "latest" ]; then
 			ddev snapshot restore --latest
 		else
@@ -128,7 +129,7 @@ drupal-fs: ## Import drupal filesystem
 drupal-deploy: ## Run drupal deployment commands
 	@echo -e " $(MSG_INFO) Running Drupal deployment commands"
 	if [ "$(DRUPAL_NO_DEPLOY)" = "true" ]; then
-		echo "Deployment disabled."
+		echo -e " $(MSG_WARNING) Deployment disabled."
 		exit 0
 	fi
 	ddev drush deploy

--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -131,19 +131,23 @@ drupal-deploy: ## Run drupal deployment commands
 
 ## Maintenance
 update: ## Update Drupal site
-	@echo "Updating Drupal"
-	composer update $(COMPOSER_FLAGS)
-	drush cr
-	drush updb $(DRUSH_FLAGS)
-	drush cex $(DRUSH_FLAGS)
+	@echo -e " $(MSG_INFO) Updating Drupal"
+	$(MAKE) drupal-update
+
+drupal-update:
+	@echo -e " $(MSG_INFO) Updating Drupal"
+	ddev composer update $(COMPOSER_FLAGS)
+	ddev drush cr
+	ddev ddev drush updb $(ddev DRUSH_FLAGS)
+	ddev drush cex $(DRUSH_FLAGS)
 
 upgrade: ## Upgrade Drupal site
-	@echo "Upgrading Drupal"
+	@echo -e " $(MSG_INFO) Upgrading project"
 	if [ -z "$$JSON_INPUT" ]; then
 		echo -e " $(MSG_ERROR) Missing upgrade operations JSON_INPUT."
 		exit 1
 	fi
-	RSH="make-cli"
+	RSH="ddev"
 	bash ./.github/actions/upgrade/upgrade.sh
 
 ## Utility
@@ -172,35 +176,51 @@ destroy: ## Destroy local runtime
 	ddev delete
 
 ## Testing
-test: drupal-test ## Run project tests
+test: drupal-validate drupal-lint drupal-analysis drupal-test-unit ## Run project tests
 
-drupal-test: ## Test Drupal
+drupal-test-list: ## List Drupal tests
+	@echo -e " $(MSG_INFO) Listing Drupal tests"
+	ddev phpunit -c ./app --list-tests
+
+drupal-test-unit: ## Run Drupal unit tests
 	@echo -e " $(MSG_INFO) Testing Drupal"
-	ddev phpunit
+	ddev phpunit -c ./app --testsuite=unit $(PHPUNIT_FLAGS)
+
+drupal-test-db: ## Run Drupal db tests
+	@echo -e " $(MSG_INFO) Running database tests"
+	echo -e " $(MSG_WARNING) Some tests could modify your existing database."
+	ddev phpunit -c ./app --testsuite=kernel,functional,existingsite $(PHPUNIT_FLAGS)
+
+drupal-test-browser: ## Run Drupal browser tests
+	@echo -e " $(MSG_INFO) Running browser tests"
+	echo -e " $(MSG_WARNING) Some tests could modify your existing database."
+	ddev phpunit -c ./app --testsuite=functional-javascript,existingsite-javascript $(PHPUNIT_FLAGS)
 
 ## Linting
-lint: drupal-validate drupal-analysis drupal-lint ## Lint project
+lint: drupal-validate drupal-lint drupal-analysis ## Lint project
 
 drupal-validate: ## Validate Drupal
 	@echo -e " $(MSG_INFO) Validating composer lock file"
 	ddev composer validate
 
-drupal-analysis: ## Static analysis of Drupal
-	@echo -e " $(MSG_INFO) Static analysis Drupal"
-	ddev phpstan
-
 drupal-lint: ## Lint Drupal
 	@echo -e " $(MSG_INFO) Linting Drupal"
 	REPO_CODE="$$(git ls-tree -d -r $$(git write-tree) --name-only | grep -E '(themes|modules)/custom/[^/]+$$' | paste -s -)"
-	ddev parallel-lint $${REPO_CODE/drupal\//} -e php,module,theme,inc,install,profile $(PARALINT_FLAGS)
-	ddev phpcs
+	ddev lint $${REPO_CODE}
+	ddev phpcs $${REPO_CODE} --standard=./app/phpcs.xml.dist
+
+drupal-analysis: ## Static analysis of Drupal
+	@echo -e " $(MSG_INFO) Running static analysis of Drupal"
+	REPO_CODE="$$(git ls-tree -d -r $$(git write-tree) --name-only | grep -E '(themes|modules)/custom/[^/]+$$' | paste -s -)"
+	ddev phpstan --configuration=app/phpstan.neon analyse $${REPO_CODE}
 
 ## Beautifying
 beauty: drupal-beauty ## Beautify & fix code in project
 
 drupal-beauty: ## Beautify & fix Drupal
 	@echo -e " $(MSG_INFO) Beautify & fixing Drupal"
-	ddev phpcbf
+	REPO_CODE="$$(git ls-tree -d -r $$(git write-tree) --name-only | grep -E '(themes|modules)/custom/[^/]+$$' | paste -s -)"
+	ddev phpcbf $${REPO_CODE} --standard=./app/phpcs.xml.dist
 
 # Helper Commands
 git-status:

--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -127,6 +127,10 @@ drupal-fs: ## Import drupal filesystem
 
 drupal-deploy: ## Run drupal deployment commands
 	@echo -e " $(MSG_INFO) Running Drupal deployment commands"
+	if [ "$(DRUPAL_NO_DEPLOY)" = "true" ]; then
+		echo "Deployment disabled."
+		exit 0
+	fi
 	ddev drush deploy
 
 ## Maintenance

--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -143,7 +143,7 @@ drupal-update:
 	@echo -e " $(MSG_INFO) Updating Drupal"
 	ddev composer update $(COMPOSER_FLAGS)
 	ddev drush cr
-	ddev ddev drush updb $(ddev DRUSH_FLAGS)
+	ddev drush updb $(ddev DRUSH_FLAGS)
 	ddev drush cex $(DRUSH_FLAGS)
 
 upgrade: ## Upgrade Drupal site

--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -45,7 +45,7 @@ quickhelp:
 
 .DEFAULT_GOAL := quickhelp
 
-## Local Dev
+## Local Development
 code: ## Launch local dev environment
 	@echo "Starting VS Code local development environment"
 	code .
@@ -175,6 +175,17 @@ destroy: ## Destroy local runtime
 	@echo -e " $(MSG_INFO) Destroying DDEV runtimes"
 	ddev delete
 
+## Tooling
+tool-chrome: ## Install DDEV Chrome extension
+	@if [ "$(REMOVE)" = "true" ]; then
+		ddev add-on remove ddev/ddev-selenium-standalone-chrome || echo -e " $(MSG_WARNING) No existing DDEV Chrome extension to remove."
+	else
+		echo -e " $(MSG_INFO) Installing DDEV Chrome extension"
+		echo -e " $(MSG_WARNING) Extension will be gitignored locally."
+		ddev add-on get ddev/ddev-selenium-standalone-chrome --version 2.1.0
+	fi
+	ddev restart
+
 ## Testing
 test: drupal-validate drupal-lint drupal-analysis drupal-test-unit ## Run project tests
 
@@ -198,6 +209,7 @@ drupal-test-db: ## Run Drupal db tests
 
 drupal-test-browser: ## Run Drupal browser tests
 	@echo -e " $(MSG_INFO) Running browser tests"
+	echo -e " $(MSG_WARNING) Make sure that the chrome tool is installed."
 	echo -e " $(MSG_WARNING) Some tests could modify your existing database."
 	ddev phpunit -c ./app --testsuite=functional-javascript,existingsite-javascript $(PHPUNIT_FLAGS)
 

--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -167,6 +167,10 @@ theme: ## Compile Drupal theme
 	drush iqsc:compile 2>/dev/null || true
 	drush cr
 
+config-pull: drupal-build ## Pull Drupal configuration
+	@echo -e " $(MSG_SUCCESS) Pulling Drupal configuration"
+	ddev drush config:pull @spot @self --yes $(DRUSH_FLAGS)
+
 stop: ## Stop local runtime
 	@echo -e " $(MSG_INFO) Stopping DDEV runtimes"
 	ddev stop

--- a/bin/ddev-shim-phpcbf
+++ b/bin/ddev-shim-phpcbf
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ "$IS_DDEV_PROJECT" != "true" ]; then
+  command="ddev exec phpcbf "$@""
+else
+  command="phpcbf "$@""
+fi
+$command

--- a/bin/ddev-shim-phpcbf-ext
+++ b/bin/ddev-shim-phpcbf-ext
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if [ "$IS_DDEV_PROJECT" != "true" ]; then
-  command="ddev exec phpcbf --extensions=php,module,inc,install,test,profile,theme,info,txt,md,yml,yaml "$@""
-else
-  command="phpcbf --extensions=php,module,inc,install,test,profile,theme,info,txt,md,yml,yaml "$@""
-fi
-$command

--- a/bin/ddev-shim-phpcs
+++ b/bin/ddev-shim-phpcs
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ "$IS_DDEV_PROJECT" != "true" ]; then
+  command="ddev exec phpcs "$@""
+else
+  command="phpcs "$@""
+fi
+$command

--- a/bin/ddev-shim-phpcs-ext
+++ b/bin/ddev-shim-phpcs-ext
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if [ "$IS_DDEV_PROJECT" != "true" ]; then
-  command="ddev exec phpcs --extensions=php,module,inc,install,test,profile,theme,info,txt,md,yml,yaml "$@""
-else
-  command="phpcs --extensions=php,module,inc,install,test,profile,theme,info,txt,md,yml,yaml "$@""
-fi
-$command

--- a/bin/ddev-shim-phpstan
+++ b/bin/ddev-shim-phpstan
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ "$IS_DDEV_PROJECT" != "true" ]; then
+  command="ddev exec phpstan "$@""
+else
+  command="phpstan "$@""
+fi
+$command

--- a/bin/ddev-shim-phpunit
+++ b/bin/ddev-shim-phpunit
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ "$IS_DDEV_PROJECT" != "true" ]; then
+  command="ddev exec phpunit "$@""
+else
+  command="phpunit "$@""
+fi
+$command

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,10 @@
     },
     "bin": [
         "bin/ddev-shim-php",
-        "bin/ddev-shim-phpcbf-ext",
-        "bin/ddev-shim-phpcs-ext"
+        "bin/ddev-shim-phpcbf",
+        "bin/ddev-shim-phpcs",
+        "bin/ddev-shim-phpstan",
+        "bin/ddev-shim-phpunit"
     ],
     "extra": {
         "project-scaffold": {


### PR DESCRIPTION
## Feature

Integrate DDEV into the `drupal-platform` to switch from the Docker Compose setup to a “standardized” internal developer platform. This will require changing the CI/CD setup and some of the local tooling.

Follow up to #50 

## Tasks

- [x] Add DDEV GitHub Actions workflows
- [x] Add Chrome support using `ddev/ddev-selenium-standalone-chrome`
- [x] Fix PHPUnit and PHPCS
- [x] Add PHPStan support
- [x] Switch to Playwright for VRT (using [`@iqual/playwright-vrt`](https://github.com/iqual-ch/playwright-vrt))

## Deprecations

* Dropped `COMPOSER_AUTH` support in GitHub Actions workflows

## Next Up

* Add DDEV `solr` support
* Update documentation in `./docs`