### PR TITLE
PF-512: Add `solr` support for DDEV

### DIFF
--- a/assets/merge/.gitignore.twig
+++ b/assets/merge/.gitignore.twig
@@ -98,8 +98,9 @@ maintenance_*.html
 .ddev/homeadditions/.ssh
 .ddev/config.ci.yaml
 
-# Ignore DDEV chrome add-on
+# Ignore some DDEV add-on folders
 .ddev/addon-metadata/*chrome/manifest.yaml
+.ddev/solr/conf/
 .ddev/*-chrome.yaml
 .ddev/*-chrome_extras.yaml
 

--- a/assets/replace/.ddev/.env.solr.twig
+++ b/assets/replace/.ddev/.env.solr.twig
@@ -1,0 +1,3 @@
+{% if runtime.solr_version is not null %}
+SOLR_BASE_IMAGE=solr:{{ runtime.solr_version }}
+{% endif %}

--- a/assets/replace/.ddev/config.solr.yaml.twig
+++ b/assets/replace/.ddev/config.solr.yaml.twig
@@ -1,0 +1,7 @@
+{% if runtime.solr_version is not null %}
+web_environment:
+    - SOLR_BASE_IMAGE=solr:{{ runtime.solr_version }}
+{% if (locations['project-root'] ~ '/solr/site_search/conf/solrconfig.xml') is existing_file %}
+    - SOLR_CORENAME=site_search
+{% endif %}
+{% endif %}

--- a/assets/replace/.ddev/config.solr.yaml.twig
+++ b/assets/replace/.ddev/config.solr.yaml.twig
@@ -1,7 +1,7 @@
 {% if runtime.solr_version is not null %}
 web_environment:
     - SOLR_BASE_IMAGE=solr:{{ runtime.solr_version }}
-{% if (locations['project-root'] ~ '/solr/site_search/conf/solrconfig.xml') is existing_file %}
+    - SOLR_HOST=solr
+    - SOLR_CORE=site_search
     - SOLR_CORENAME=site_search
-{% endif %}
 {% endif %}

--- a/assets/replace/.ddev/config.solr.yaml.twig
+++ b/assets/replace/.ddev/config.solr.yaml.twig
@@ -1,6 +1,5 @@
 {% if runtime.solr_version is not null %}
 web_environment:
-    - SOLR_BASE_IMAGE=solr:{{ runtime.solr_version }}
     - SOLR_HOST=solr
     - SOLR_CORE=site_search
     - SOLR_CORENAME=site_search

--- a/assets/replace/.ddev/docker-compose.solr.yaml.twig
+++ b/assets/replace/.ddev/docker-compose.solr.yaml.twig
@@ -69,7 +69,7 @@ services:
 
     # The odd need to use $$SOLR_CORENAME here is explained in
     # https://stackoverflow.com/a/48189916/215713
-    entrypoint: 'bash -c "VERBOSE=yes [ -d /var/solr/data/site_search/conf ] && cp /solr-conf/conf/* /var/solr/data/site_search/conf; solr-precreate site_search /solr-conf"'
+    entrypoint: 'bash -c "VERBOSE=yes mkdir -p /var/solr/data; [ -d /var/solr/data/site_search/conf ] && cp /solr-conf/conf/* /var/solr/data/site_search/conf; solr-precreate site_search /solr-conf"'
 {% endif %}
 
     external_links:

--- a/assets/replace/.ddev/docker-compose.solr.yaml.twig
+++ b/assets/replace/.ddev/docker-compose.solr.yaml.twig
@@ -1,0 +1,84 @@
+{% if runtime.solr_version is not null %}
+# DDEV Apache Solr recipe file.
+# Based on: https://github.com/ddev/ddev-drupal-solr/blob/v1.3.1/docker-compose.solr.yaml
+#
+# To access Solr after it is installed:
+# - The Solr admin interface will be accessible at:
+#   http://<projectname>.ddev.site:8983/solr/
+#   For example, if the project is named "myproject" the hostname will be:
+#   http://myproject.ddev.site:8983/solr/
+# - To access the Solr container from the web container use:
+#   http://solr:8983/solr/
+# - A Solr core is automatically created with the name "dev" unless you
+#   change that usage throughout. It can be
+#   accessed at the URL: http://solr:8983/solr/dev (inside web container)
+#   or at http://myproject.ddev.site:8983/solr/dev (on the host)
+
+services:
+  solr:
+    # Name of container using standard ddev convention
+    container_name: ddev-${DDEV_SITENAME}-solr
+    # The solr docker image is at https://hub.docker.com/_/solr/
+    # and code at https://github.com/docker-solr/docker-solr
+    # README: https://github.com/docker-solr/docker-solr/blob/master/README.md
+    # It's almost impossible to work with it if you don't read the docs there
+    image: ${SOLR_BASE_IMAGE:-solr:8}-${DDEV_SITENAME}-built
+    build:
+      dockerfile_inline: |
+        ARG SOLR_BASE_IMAGE="scratch"
+        FROM $$SOLR_BASE_IMAGE
+        # Fix HTTPS redirect to HTTP which breaks URL for Solr Admin UI.
+        # The reason for this problem is that Solr uses Jetty as a webserver.
+        # Jetty has X-Forwarded- headers disabled by default, enable them here:
+        USER root
+        RUN sed -i '/X-Forwarded-/,/-->/ {/<!--/d; /-->/d}' /opt/solr/server/etc/jetty.xml
+        USER solr
+      args:
+        SOLR_BASE_IMAGE: ${SOLR_BASE_IMAGE:-solr:8}
+    restart: "no"
+    # Solr is served from this port inside the container.
+    expose:
+      - 8983
+    # These labels ensure this service is discoverable by ddev.
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: ${DDEV_APPROOT}
+    environment:
+      # This defines the host name the service should be accessible from. This
+      # will be sitename.ddev.site.
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      # HTTP_EXPOSE exposes http traffic from the container port 8983
+      # to the host port 8983 vid ddev-router reverse proxy.
+      - HTTP_EXPOSE=8983:8983
+      - HTTPS_EXPOSE=8943:8983
+    volumes:
+      # solr core *data* is stored on the 'solr' docker volume
+      # This mount is optional; without it your search index disappears
+      # each time the ddev project is stopped and started.
+      - solr:/var/solr
+
+      - ".:/mnt/ddev_config"
+      - ddev-global-cache:/mnt/ddev-global-cache
+
+{% if (locations['project-root'] ~ '/solr/site_search/conf/solrconfig.xml') is existing_file %}
+      # This mounts the conf in .ddev/solr into the container where
+      # the solr-precreate command in the entrypoint uses it as a one-time
+      # configuration to copy config into the newly-created core. It is not
+      # used if the core has previously been created.
+      - ../solr/site_search:/solr-conf
+
+    # The odd need to use $$SOLR_CORENAME here is explained in
+    # https://stackoverflow.com/a/48189916/215713
+    entrypoint: 'bash -c "VERBOSE=yes [ -d /var/solr/data/site_search/conf ] && cp /solr-conf/conf/* /var/solr/data/site_search/conf; solr-precreate site_search /solr-conf"'
+{% endif %}
+
+    external_links:
+      - "ddev-router:${DDEV_SITENAME}.${DDEV_TLD}"
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail -s localhost:8983/solr/"]
+
+volumes:
+  # solr is a persistent Docker volume for solr data
+  solr:
+    name: "ddev-${DDEV_SITENAME}_solr"
+{% endif %}

--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -184,6 +184,13 @@ destroy: ## Destroy local runtime
 	@echo -e " $(MSG_INFO) Destroying DDEV runtimes"
 	ddev delete
 
+## Services
+service-solr: ## Install DDEV Solr service
+	@echo -e " $(MSG_INFO) Installing DDEV Solr service"
+	ddev composer config extra.project-scaffold.runtime --json '{"solr_version": "9.9"}' --merge
+	ddev composer project:scaffold
+	ddev restart
+
 ## Tooling
 tool-chrome: ## Install DDEV Chrome extension
 	@if [ "$(REMOVE)" = "true" ]; then

--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -187,7 +187,7 @@ destroy: ## Destroy local runtime
 ## Services
 service-solr: ## Install DDEV Solr service
 	@echo -e " $(MSG_INFO) Installing DDEV Solr service"
-	ddev composer config extra.project-scaffold.runtime --json '{"solr_version": "9.9"}' --merge
+	ddev composer config extra.project-scaffold.runtime --json '{"solr_version": "9.2"}' --merge
 	ddev composer project:scaffold
 	ddev restart
 

--- a/assets/replace/solr/site_search/conf/README.md.twig
+++ b/assets/replace/solr/site_search/conf/README.md.twig
@@ -5,5 +5,5 @@ In order for the `solr` integration to work properly, you need to add the solr c
 
 Make sure to follow the documentation to add the `site_search` Solr configuration. After adding the configuration you have to execute `composer project:scaffold` and reboot your environment.
 
-> This file is removed if a `sorconfig.xml` exists in this directory when `composer project:scaffold` is run.
+> This file is removed if a `solrconfig.xml` exists in this directory when `composer project:scaffold` is run.
 {% endif %}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,14 +172,17 @@ If a `runtime.solr_version` is defined (e.g. `9.2` instead of `null`) then an ad
 
 In order to create a new Solr core for use with the search API, the following steps have to be followed:
 
+> [!WARNING]
+> The `solr` setup has only been tested with `solr` version `8.11` and `9.2`.
+
 1. Install the Search API Solr module:
 
 ```bash
-composer require drupal/search_api_solr
-drush en search_api_solr
+ddev composer require drupal/search_api_solr
+ddev drush en search_api_solr
 ```
 
-2. Enable the Solr integration in the Drupal Platform, and set a version (e.g. Solr version `9.9`, including minor):
+2. Enable the Solr integration in the Drupal Platform, and set a version (e.g. Solr version `9.2`, including minor):
 
 ```bash
 make service-solr
@@ -187,13 +190,13 @@ make service-solr
 
 3. Add a server in the administration backend of the Drupal Search API module (`/admin/config/search/search-api/add-server`). Use `solr` as server (and system) name, as well as host. Use `site_search` as Solr core name.
 
-4. Download the core configuration and add it to the project repository (e.g. including major version `9`):
+4. Download the core configuration and add it to the project repository (e.g. including major version `9.2`):
 
 ```bash
-drush solr-gsc solr config.zip 9
+ddev drush solr-gsc solr config.zip 9.2
 unzip ./app/public/config.zip -d ./solr/site_search/conf
 rm ./app/public/config.zip
-composer project:scaffold
+ddev composer project:scaffold
 ```
 
 5. Make sure to restart DDEV. This will create the core as configured.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,18 +179,15 @@ composer require drupal/search_api_solr
 drush en search_api_solr
 ```
 
-2. Enable the Solr integration in the Drupal Platform, and set a version (e.g. Solr version `9.2`, including minor):
+2. Enable the Solr integration in the Drupal Platform, and set a version (e.g. Solr version `9.9`, including minor):
 
 ```bash
-composer config extra.project-scaffold.runtime --json '{"solr_version": "9.2"}' --merge
-composer project:scaffold
+make service-solr
 ```
 
-3. Make sure to rebuild the container in VS Code so Solr is started (without a core for initial configuration).
+3. Add a server in the administration backend of the Drupal Search API module (`/admin/config/search/search-api/add-server`). Use `solr` as server (and system) name, as well as host. Use `site_search` as Solr core name.
 
-4. Add a server in the administration backend of the Drupal Search API module (`/admin/config/search/search-api/add-server`). Use `solr` as server (and system) name, as well as host. Use `site_search` as Solr core name.
-
-5. Download the core configuration and add it to the project repository (e.g. including major version `9`):
+4. Download the core configuration and add it to the project repository (e.g. including major version `9`):
 
 ```bash
 drush solr-gsc solr config.zip 9
@@ -199,6 +196,10 @@ rm /project/app/public/config.zip
 composer project:scaffold
 ```
 
-6. Make sure to rebuild the container in VS Code so Solr is started. This will create the core as configured.
+5. Make sure to restart DDEV. This will create the core as configured.
+
+```bash
+ddev restart
+```
 
 You should now have a running Solr service with a core created from the configuration in the `solr` directory. Follow the Search API module's documentation on how to create indexes.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -191,8 +191,8 @@ make service-solr
 
 ```bash
 drush solr-gsc solr config.zip 9
-unzip /project/app/public/config.zip -d /project/solr/site_search/conf
-rm /project/app/public/config.zip
+unzip ./app/public/config.zip -d ./solr/site_search/conf
+rm ./app/public/config.zip
 composer project:scaffold
 ```
 


### PR DESCRIPTION
## Feature

Integrate the `solr` service for the local DDEV setup. Follow up to #51.

## Tasks

- [x] Add `solr` DDEV service

## Comments

* Based on https://github.com/ddev/ddev-drupal-solr

## Next Up

* Update documentation in `./docs`