### PR TITLE
PF-512: Add multi domain support to DDEV

### DIFF
--- a/assets/replace/.ddev/config.yaml.twig
+++ b/assets/replace/.ddev/config.yaml.twig
@@ -4,7 +4,8 @@ docroot: app/public
 php_version: "{{ runtime.php_version }}"
 webserver_type: nginx-fpm
 xdebug_enabled: false
-additional_hostnames: []
+additional_hostnames:
+  - "*.{{ name }}"
 additional_fqdns: []
 database:
     type: mariadb


### PR DESCRIPTION
# Feature

Add support for any subdomain on the DDEV development domain. For example `bar.foo.ddev.site` for the `foo` project. This should provide backwards compatibility for multi domain projects.

## Tasks

- [x] Add multi domain support to DDEV