### PR TITLE
PF-512: Add `DRUPAL_SPOT_ORIGIN` for file proxy setting

### DIFF
--- a/assets/add/@web-root/sites/default/local.settings.php.twig
+++ b/assets/add/@web-root/sites/default/local.settings.php.twig
@@ -88,7 +88,3 @@ $settings['config_exclude_modules'] = ['devel', 'devel_entity_updates', 'iq_stag
 $settings['trusted_host_patterns'] = [
   '^.+$',
 ];
-
-// iqual stage file proxy config
-$config['iq_stage_file_proxy.settings']['remote_instance'] = '{{ url }}';
-// $config['iq_stage_file_proxy.settings']['offload'] = FALSE;

--- a/assets/merge/.env.twig
+++ b/assets/merge/.env.twig
@@ -7,3 +7,4 @@ PLATFORMSH_PROJECT_ID={{ platformsh_config.project_id }}
 
 # Drupal single point of truth for db/fs
 DRUPAL_SPOT={{ drupal_spot }}
+DRUPAL_SPOT_ORIGIN={{ url }}

--- a/assets/replace/.ddev/config.yaml.twig
+++ b/assets/replace/.ddev/config.yaml.twig
@@ -18,6 +18,8 @@ corepack_enable: true
 ddev_version_constraint: '>= 1.24.0'
 web_environment:
     - DRUPAL_ENVIRONMENT=local
+    - DRUPAL_SPOT={{ drupal_spot }}
+    - DRUPAL_SPOT_ORIGIN={{ url }}
     - SIMPLETEST_DB=$DDEV_DATABASE_FAMILY://db:db@db/db
     - SIMPLETEST_BASE_URL=$DDEV_PRIMARY_URL
     - DTT_BASE_URL=$DDEV_PRIMARY_URL

--- a/assets/replace/@web-root/sites/default/settings.php
+++ b/assets/replace/@web-root/sites/default/settings.php
@@ -220,4 +220,10 @@ if (file_exists($app_root . '/' . $site_path . '/services.local.yml')) {
 $ddev_settings = __DIR__ . '/settings.ddev.php';
 if (getenv('IS_DDEV_PROJECT') == 'true' && is_readable($ddev_settings)) {
   require $ddev_settings;
+
+  // Set Stage File Proxy origin if provided.
+  if (getenv('DRUPAL_SPOT_ORIGIN')) {
+    $config['iq_stage_file_proxy.settings']['remote_instance'] = getenv('DRUPAL_SPOT_ORIGIN');
+    $config['stage_file_proxy.settings']['origin'] = getenv('DRUPAL_SPOT_ORIGIN');
+  }
 }


### PR DESCRIPTION
## Feature

Automatically set the remote origin/URL for the stage file proxy (both iqual's and the community version). Add a new `DRUPAL_SPOT_ORIGIN` environment variable that is then picked up by the `settings.php`.

## Tasks

- [x] Add `DRUPAL_SPOT_ORIGIN` for file proxy setting