### PR TITLE
PF-525: Improve upgrade script command execution

### DIFF
--- a/assets/replace/.github/actions/upgrade/upgrade.sh
+++ b/assets/replace/.github/actions/upgrade/upgrade.sh
@@ -180,6 +180,9 @@ for operation in "${OPERATIONS[@]}"; do
     "updatedb")
       rsh drush updatedb "${OPTIONS_ARRAY[@]}" -y
       ;;
+    "cache:rebuild")
+      rsh drush cache:rebuild
+      ;;
     "pm:enable")
       rsh drush pm:enable "${OPTIONS_ARRAY[@]}" -y "${DATA_ARRAY[@]}"
       ;;

--- a/assets/replace/.github/actions/upgrade/upgrade.sh
+++ b/assets/replace/.github/actions/upgrade/upgrade.sh
@@ -96,18 +96,26 @@ for operation in "${OPERATIONS[@]}"; do
     continue
   fi
 
-  OPTIONS=$(echo "${operation}" | jq -r '.options // ""')
+  # Parse OPTIONS into an array to preserve arguments with spaces
+  OPTIONS_STRING=$(echo "${operation}" | jq -r '.options // ""')
+  if [[ -n "${OPTIONS_STRING}" ]]; then
+    read -ra OPTIONS_ARRAY <<< "$OPTIONS_STRING"
+  else
+    OPTIONS_ARRAY=()
+  fi
 
-  # Parse data variable and convert arrays into whitespace separated list.
+  # Parse DATA into an array to preserve each item separately (handles spaces in items)
   DATA_INPUT=$(echo "${operation}" | jq '.data')
   if [[ -n "${DATA_INPUT}" ]] && [[ "${DATA_INPUT}" != "null" ]]; then
     if echo "${DATA_INPUT}" | jq -e 'type=="array"' > /dev/null; then
-        DATA=$(echo "${DATA_INPUT}" | jq -r 'join(" ")')
+      # Convert JSON array to bash array, one element per line
+      readarray -t DATA_ARRAY < <(echo "${DATA_INPUT}" | jq -r '.[]')
     else
-        DATA=$(echo "${DATA_INPUT}" | jq -r '.')
+      # Single value - convert to single-element array
+      DATA_ARRAY=("$(echo "${DATA_INPUT}" | jq -r '.')")
     fi
   else
-    DATA=
+    DATA_ARRAY=()
   fi
 
   KEY=$(echo "${operation}" | jq -r '.key')
@@ -115,29 +123,32 @@ for operation in "${OPERATIONS[@]}"; do
   # Switch to relevant action.
   case "${ACTION}" in
     "remove")
-      rsh composer remove ${OPTIONS} -n ${DATA} -d ${APP_ROOT}
+      rsh composer remove "${OPTIONS_ARRAY[@]}" -n "${DATA_ARRAY[@]}" -d "${APP_ROOT}"
       ;;
     "require")
-      rsh composer require ${OPTIONS} -n ${DATA} -d ${APP_ROOT}
+      rsh composer require "${OPTIONS_ARRAY[@]}" -n "${DATA_ARRAY[@]}" -d "${APP_ROOT}"
       ;;
     "update")
-      rsh composer update ${OPTIONS} -n ${DATA} -d ${APP_ROOT}
+      rsh composer update "${OPTIONS_ARRAY[@]}" -n "${DATA_ARRAY[@]}" -d "${APP_ROOT}"
       ;;
     "bump")
-      rsh composer bump ${PACKAGES} -n -d ${APP_ROOT}
+      # @todo: PACKAGES variable is undefined - this looks like a bug in the original script
+      rsh composer bump ${PACKAGES} -n -d "${APP_ROOT}"
       ;;
     "config")
       if [[ "${KEY}" =~ "extra."* ]] || [[ "${KEY}" =~ "repositories."* ]]; then
+        # For complex configs, use JSON format to preserve structure
         DATA_JSON=$(echo "${operation}" | jq -c '.data')
-        rsh composer config ${KEY} ${OPTIONS} --json "${DATA_JSON}" -n -d ${APP_ROOT}
+        rsh composer config "${KEY}" "${OPTIONS_ARRAY[@]}" --json "${DATA_JSON}" -n -d "${APP_ROOT}"
       else
-        rsh composer config ${KEY} ${DATA} ${OPTIONS} -n -d ${APP_ROOT}
+        # For simple configs, pass data array elements
+        rsh composer config "${KEY}" "${DATA_ARRAY[@]}" "${OPTIONS_ARRAY[@]}" -n -d "${APP_ROOT}"
       fi
       ;;
     "rector")
-      if ! grep -q "palantirnet/drupal-rector" $COMPOSER_JSON_FILE; then
+      if ! grep -q "palantirnet/drupal-rector" "$COMPOSER_JSON_FILE"; then
         echo "Rector is not present, installing it temporarily."
-        rsh composer require --dev palantirnet/drupal-rector -n -d ${APP_ROOT}
+        rsh composer require --dev palantirnet/drupal-rector -n -d "${APP_ROOT}"
         RECTOR_INSTALLED=true
       fi
       RECTOR_CONFIG="${APP_ROOT}/rector.php"
@@ -145,74 +156,80 @@ for operation in "${OPERATIONS[@]}"; do
         echo "Rector configuration is not present, using default."
         RECTOR_CONFIG=".github/actions/upgrade/rector.php"
       fi
-      if [ -z "$DATA" ]; then
+      if [[ ${#DATA_ARRAY[@]} -eq 0 ]]; then
         echo "No path defined. Auto-generating themes and module custom path."
-        DATA="$(git ls-tree -d -r $(git write-tree) --name-only | grep -E '(themes|modules)/custom/[^/]+$' | paste -s -)"
+        # Build array from auto-generated paths
+        readarray -t DATA_ARRAY < <(git ls-tree -d -r $(git write-tree) --name-only | grep -E '(themes|modules)/custom/[^/]+$')
       fi
-      rsh rector process ${DATA} ${OPTIONS} --config ${RECTOR_CONFIG}
+      rsh rector process "${DATA_ARRAY[@]}" "${OPTIONS_ARRAY[@]}" --config "${RECTOR_CONFIG}"
       if [ -n "$RECTOR_INSTALLED" ]; then
-        rsh composer remove --dev palantirnet/drupal-rector -n -d ${APP_ROOT}
+        rsh composer remove --dev palantirnet/drupal-rector -n -d "${APP_ROOT}"
       fi
       ;;
     "phpcbf")
-      if grep -q "drupal/coder" $COMPOSER_JSON_FILE; then
-        if [ -z "$DATA" ]; then
+      if grep -q "drupal/coder" "$COMPOSER_JSON_FILE"; then
+        if [[ ${#DATA_ARRAY[@]} -eq 0 ]]; then
           echo "No path defined. Auto-generating themes and module custom path."
-          DATA="$(git ls-tree -d -r $(git write-tree) --name-only | grep -E '(themes|modules)/custom/[^/]+$' | paste -s -)"
+          # Build array from auto-generated paths
+          readarray -t DATA_ARRAY < <(git ls-tree -d -r $(git write-tree) --name-only | grep -E '(themes|modules)/custom/[^/]+$')
         fi
-        rsh phpcbf ${OPTIONS} ${DATA} || true
+        rsh phpcbf "${OPTIONS_ARRAY[@]}" "${DATA_ARRAY[@]}" || true
       else
         echo "Warning: missing \"drupal/coder\" package for code beautifying"
       fi
       ;;
     "updatedb")
-      rsh drush updatedb ${OPTIONS} -y
+      rsh drush updatedb "${OPTIONS_ARRAY[@]}" -y
       ;;
     "pm:enable")
-      rsh drush pm:enable ${OPTIONS} -y ${DATA}
+      rsh drush pm:enable "${OPTIONS_ARRAY[@]}" -y "${DATA_ARRAY[@]}"
       ;;
     "pm:uninstall")
-      rsh drush pm:uninstall ${OPTIONS} -y ${DATA}
+      rsh drush pm:uninstall "${OPTIONS_ARRAY[@]}" -y "${DATA_ARRAY[@]}"
       ;;
     "theme:enable")
-      rsh drush theme:enable ${OPTIONS} -y ${DATA}
+      rsh drush theme:enable "${OPTIONS_ARRAY[@]}" -y "${DATA_ARRAY[@]}"
       ;;
     "theme:uninstall")
-      rsh drush theme:uninstall ${OPTIONS} -y ${DATA}
+      rsh drush theme:uninstall "${OPTIONS_ARRAY[@]}" -y "${DATA_ARRAY[@]}"
       ;;
     "config:export")
-      rsh drush config:export -y ${OPTIONS}
+      rsh drush config:export -y "${OPTIONS_ARRAY[@]}"
       ;;
     "config:set")
       # Requires at least drush v11
+      # Use JSON format to preserve complex data structures
       DATA_JSON=$(echo "${operation}" | jq -c '.data')
-      rsh drush config:set -y ${OPTIONS} --input-format=yaml "${KEY}" ? "${DATA_JSON}"
+      rsh drush config:set -y "${OPTIONS_ARRAY[@]}" --input-format=yaml "${KEY}" ? "${DATA_JSON}"
       ;;
     "project:scaffold")
-      rsh composer project:scaffold -n ${OPTIONS} -d ${APP_ROOT}
+      rsh composer project:scaffold -n "${OPTIONS_ARRAY[@]}" -d "${APP_ROOT}"
       ;;
     "drupal:scaffold")
-      rsh composer drupal:scaffold -n ${OPTIONS} -d ${APP_ROOT}
+      rsh composer drupal:scaffold -n "${OPTIONS_ARRAY[@]}" -d "${APP_ROOT}"
       ;;
     "patch-add")
-      if grep -q "szeidler/composer-patches-cli" $COMPOSER_JSON_FILE; then
-        declare -a "DATA_ARRAY=($DATA)"
-        rsh composer patch-add ${OPTIONS} -n "${DATA_ARRAY[@]}" -d ${APP_ROOT}
+      if grep -q "szeidler/composer-patches-cli" "$COMPOSER_JSON_FILE"; then
+        # DATA_ARRAY is already properly populated from JSON parsing above
+        rsh composer patch-add "${OPTIONS_ARRAY[@]}" -n "${DATA_ARRAY[@]}" -d "${APP_ROOT}"
       else
         echo "Warning: missing \"szeidler/composer-patches-cli\" package for patch CLI."
       fi
       ;;
     "patch-remove")
-      if grep -q "szeidler/composer-patches-cli" $COMPOSER_JSON_FILE; then
-        declare -a "DATA_ARRAY=($DATA)"
-        rsh composer patch-remove ${OPTIONS} -n "${DATA_ARRAY[@]}" -d ${APP_ROOT}
+      if grep -q "szeidler/composer-patches-cli" "$COMPOSER_JSON_FILE"; then
+        # DATA_ARRAY is already properly populated from JSON parsing above
+        rsh composer patch-remove "${OPTIONS_ARRAY[@]}" -n "${DATA_ARRAY[@]}" -d "${APP_ROOT}"
       else
         echo "Warning: missing \"szeidler/composer-patches-cli\" package for patch CLI."
       fi
       ;;
     "commit")
-      echo "git add . && git commit ${OPTIONS} -m \"${DATA}\" || true"
-      git add . && git commit ${OPTIONS} -m "${DATA}" || true
+      # For commit, DATA contains the commit message which should be a single string
+      # Join DATA_ARRAY if it has multiple elements (shouldn't normally happen)
+      COMMIT_MSG="${DATA_ARRAY[*]}"
+      echo "git add . && git commit ${OPTIONS_ARRAY[@]} -m \"${COMMIT_MSG}\" || true"
+      git add . && git commit "${OPTIONS_ARRAY[@]}" -m "${COMMIT_MSG}" || true
       ;;
     "reboot")
       echo "make deploy-local COMPOSE_FLAGS=-d"

--- a/assets/replace/.github/actions/upgrade/upgrade.sh
+++ b/assets/replace/.github/actions/upgrade/upgrade.sh
@@ -132,8 +132,7 @@ for operation in "${OPERATIONS[@]}"; do
       rsh composer update "${OPTIONS_ARRAY[@]}" -n "${DATA_ARRAY[@]}" -d "${APP_ROOT}"
       ;;
     "bump")
-      # @todo: PACKAGES variable is undefined - this looks like a bug in the original script
-      rsh composer bump ${PACKAGES} -n -d "${APP_ROOT}"
+      rsh composer bump "${OPTIONS_ARRAY[@]}" "${DATA_ARRAY[@]}" -n -d "${APP_ROOT}"
       ;;
     "config")
       if [[ "${KEY}" =~ "extra."* ]] || [[ "${KEY}" =~ "repositories."* ]]; then

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -5,19 +5,20 @@ There are multiple GitHub Action workflows for running common automation tasks.
 * [Update: Updating Drupal projects](#update-drupal-project)
 * [Upgrade: Upgrading Drupal projects with specific operations](#upgrade-drupal-project)
 * [Testing: Test the Drupal project](#testing)
-  * [PHPCS: Linting](#phpcs)
-  * [PHPUnit: Unit Testing](#phpunit-unit-testing)
-  * [PHPUnit: Functional Testing](#phpunit-functional-testing)
-  * [Visual Regression Testing: Comparing reference website to local test deployment](#visual-regression-testing)
+   * [PHPCS: Linting](#phpcs)
+   * [PHPUnit: Unit Testing](#phpunit-unit-testing)
+   * [PHPUnit: Functional Testing](#phpunit-functional-testing)
+   * [Visual Regression Testing: Comparing reference website to local test deployment](#visual-regression-testing)
 
 ## Update Drupal Project
 
 * Workflow: `update.yml`
 * Config variable: `workflows.update`
 * Runs on:
-    * Manual dispatch
+   * Manual dispatch
+
 * Inputs
-    * Token: GitHub Personal Access Token
+   * Token: GitHub Personal Access Token
 
 This workflow will install the project in a GitHub Actions runner environment and run the Drupal update process on it (`make update`). If successful it will create a pull request with the changes. If a token is provided then the pull request created by this workflow will trigger other workflows running on push or pull request triggers.
 
@@ -26,14 +27,15 @@ This workflow will install the project in a GitHub Actions runner environment an
 * Workflow: `upgrade.yml`
 * Config variable: `workflows.upgrade`
 * Runs on:
-    * Manual dispatch
+   * Manual dispatch
+
 * Inputs
-    * Token: GitHub Personal Access Token
-    * Require: Composer require a module or list of modules
-    * Remove: Composer remove a module or list of modules
-    * Enable: Enable a module or list of modules with Drush
-    * Uninstall: Uninstall a module or list of modules with Drush
-    * Payload: JSON encoded operation payload for advanced usage
+   * Token: GitHub Personal Access Token
+   * Require: Composer require a module or list of modules
+   * Remove: Composer remove a module or list of modules
+   * Enable: Enable a module or list of modules with Drush
+   * Uninstall: Uninstall a module or list of modules with Drush
+   * Payload: JSON encoded operation payload for advanced usage
 
 This workflow will install the project in a GitHub Actions runner environment and run the Drupal upgrade process on it (`make upgrade`) using either the provided `require`, `remove`, `enable` and `uninstall` inputs or the provided `payload` (`payload` always overrides other inputs). If successful it will create a pull request with the changes. If a token is provided then the pull request created by this workflow will trigger other workflows running on push or pull request triggers.
 
@@ -43,16 +45,17 @@ This workflow will install the project in a GitHub Actions runner environment an
 * `require`: Requiring new or upgrading existing packages with `composer require`.
 * `update`: Updating packages with existing version constraints with `composer update`.
 * `bump`: Bumping the version constraints in the requirements according to the installed versions with `composer bump`.
-* `config`: Changing the composer config with `composer config` (repositories, platform, or extra like project-scaffold).
+* `config`: Changing the composer config with `composer config` (repositories, platform, or extra like project-scaffold). Requires `key` field.
 * `rector`: Drupal rector for running automated code fixes and upgrades with `rector` (for custom project modules).
 * `phpcbf`: PHP code beautifying with `phpcbf` for improving code quality (for custom project modules).
 * `updatedb`: Drupal database updates with `drush updatedb`.
-* `enable`: Enabling Drupal modules with `drush pm:enable`.
-* `uninstall`: Uninstalling/disabling Drupal modules with `drush pm:uninstall`.
-* `enable`: Enabling Drupal themes `drush theme:enable`.
-* `uninstall`: Uninstalling/disabling Drupal themes `drush theme:uninstall`.
-* `export`: Exporting the Drupal configuration `drush config:export`.
-* `set`: Setting Drupal configuration with`drush config:set` (e.g. site title).
+* `cache:rebuild`: Drupal cache rebuild with `drush cache:rebuild`.
+* `pm:enable`: Enabling Drupal modules with `drush pm:enable`.
+* `pm:uninstall`: Uninstalling/disabling Drupal modules with `drush pm:uninstall`.
+* `theme:enable`: Enabling Drupal themes with `drush theme:enable`.
+* `theme:uninstall`: Uninstalling/disabling Drupal themes with `drush theme:uninstall`.
+* `config:export`: Exporting the Drupal configuration with `drush config:export`.
+* `config:set`: Setting Drupal configuration with `drush config:set` (e.g. site title). Requires `key` field.
 * `project:scaffold`: Scaffolding project assets with `composer project:scaffold`.
 * `drupal:scaffold`: Scaffolding drupal assets with `composer drupal:scaffold`.
 * `patch-add`: Adding patches to composer with `composer patch-add`.
@@ -65,12 +68,13 @@ This workflow will install the project in a GitHub Actions runner environment an
 A JSON payload has to follow this structure:
 
 * `operations`: Operations Array (`array`)
-    * Operation object
-        * `match`: (optional) Matching a requirement (key) in the `require` or `require-dev` of the `composer.json` (`string`)
-        * `matchInverse`: (optional) Inverse matching a requirement (key) in the `require` or `require-dev` of the `composer.json` (`string`)
-        * `action`: The desired action (e.g. `require`) (`string`)
-        * `data`: (optional) The data for the action (e.g. `dompdf/dompdf`) (`string`|`array`)
-        * `options`: (optional) Options for the action (e.g. `--dev`) (`string`)
+   * Operation object
+      * `match`: (optional) Matching a requirement (key) in the `require` or `require-dev` of the `composer.json` (`string`)
+      * `matchInverse`: (optional) Inverse matching a requirement (key) in the `require` or `require-dev` of the `composer.json` (`string`)
+      * `action`: The desired action (e.g. `require`) (`string`)
+      * `data`: (optional) The data for the action (e.g. `dompdf/dompdf`) (`string`|`array`)
+      * `options`: (optional) Options for the action (e.g. `--dev`) (`string`)
+      * `key`: (required for `config` and `config:set` actions) The configuration key to set (e.g. `platform.php`) (`string`)
 
 An example operation for removing `dompdf/dompdf` if it is installed and requiring `iqual/iq_barrio` and `drupal/antibot:^2.0` and updating all depedencies would look like this:
 
@@ -87,10 +91,10 @@ An example operation for removing `dompdf/dompdf` if it is installed and requiri
             "action": "require",
             "data": [
                 "iqual/iq_barrio",
-                "drupal/antibot:^2.0",
+                "drupal/antibot:^2.0"
             ],
             "options": "--with-all-dependencies"
-        },
+        }
     ]
 }
 ```
@@ -125,7 +129,7 @@ An example operation for removing `dompdf/dompdf` if it is installed and requiri
         "data": "Removed legacy root requirements"
       },
       {
-        "action": "rector",
+        "action": "rector"
       },
       {
         "action": "phpcbf",
@@ -159,7 +163,7 @@ An example operation for removing `dompdf/dompdf` if it is installed and requiri
         "action": "require",
         "data": [
           "iqual/iq_barrio",
-          "drupal/antibot:^2.0",
+          "drupal/antibot:^2.0"
         ],
         "options": "--with-all-dependencies"
       },
@@ -191,13 +195,14 @@ An example operation for removing `dompdf/dompdf` if it is installed and requiri
 * Workflow: `testing.yml`
 * Config variable: `workflows.phpunit`
 * Runs on:
-    * Manual dispatch
-    * Pull request (re)open
+   * Manual dispatch
+   * Pull request (re)open
+
 * Calls:
-    * PHPCS
-    * PHPUnit Unit Testing
-    * PHPUnit Functional Testing
-    * Visual Regression Testing
+   * PHPCS
+   * PHPUnit Unit Testing
+   * PHPUnit Functional Testing
+   * Visual Regression Testing
 
 This workflow runs extensive Drupal testing by running a full build, linting and PHPUnit unit test in parallel. If the build succeeds it will also run PHPUnit database and browser test, as well as visual regression testing. The workflow can be dispatched manually, but will also run on PR creation. When it is run against a PR it will also directly annotate the files that are throwing errors or warnings.
 
@@ -206,8 +211,8 @@ This workflow runs extensive Drupal testing by running a full build, linting and
 * Workflow: `phpcs.yml`
 * Config variable: `workflows.phpunit`
 * Runs on:
-    * Manual dispatch
-    * Call from other workflow
+   * Manual dispatch
+   * Call from other workflow
 
 This workflow will first run `parallel-lint` to check the syntax of all custom themes & modules in the repository. Afterwards it will run `phpcs` to code sniff according to the Drupal standards.
 
@@ -216,8 +221,8 @@ This workflow will first run `parallel-lint` to check the syntax of all custom t
 * Workflow: `phpunit-unit-testing.yml`
 * Config variable: `workflows.phpunit`
 * Runs on:
-    * Manual dispatch
-    * Call from other workflow
+   * Manual dispatch
+   * Call from other workflow
 
 This workflow will run the "unit" testsuite according to the `phpunit.xml` (fallback to `phpunit.xml.dist`) in the repository. This type of testing doesn't require a full Drupal build and will not use the images defined in `manifests/local`.
 
@@ -226,10 +231,11 @@ This workflow will run the "unit" testsuite according to the `phpunit.xml` (fall
 * Workflow: `phpunit-functional-testing.yml`
 * Config variable: `workflows.phpunit`
 * Runs on:
-    * Manual dispatch
-    * Call from other workflow
+   * Manual dispatch
+   * Call from other workflow
+
 * Inputs
-    * Testing Type: The type of test to run (database or browser)
+   * Testing Type: The type of test to run (database or browser)
 
 This workflow will run different testsuites according to the `phpunit.xml` (fallback to `phpunit.xml.dist`) in the repository depending on the input type of test:
 
@@ -243,8 +249,8 @@ This workflow requires a full build of Drupal.
 * Workflow: `visual-regression-testing.yml`
 * Config variable: `workflows.vrt`
 * Runs on:
-    * Manual dispatch
-    * Pull request (re)open (`workflows.phpunit` disabled)
-    * Call from other workflow (`workflows.phpunit` enabled)
+   * Manual dispatch
+   * Pull request (re)open (`workflows.phpunit` disabled)
+   * Call from other workflow (`workflows.phpunit` enabled)
 
 This workflow will install the project in a GitHub Actions runner environment and run a visual regression test on it ([iqual-ch/ci-pocketknife-installer](https://github.com/iqual-ch/ci-pocketknife-installer) and [iqual-ch/ci-pocketknife](https://github.com/iqual-ch/ci-pocketknife/)). This workflow requires a `.env.visreg` file setting the test and reference website URLs for testing. The workflow will crawl the website for relevant links. If the test fails (when there are visual differences between the two websites), then it will upload a BackstopJS report as a workflow artifact.


### PR DESCRIPTION
## Issue

* If there is a `composer require "org/example:dev-1.x as 1.0.0"` requirement, it will fail due to the whitespace
* Add a `drush cache:rebuild`
* The composer bump action has a bug and probably won’t work
* Some documentation is incorrect

## Tasks

- [x] Fix whitespace issue and refactored variables
- [x] Fix `bump` action
- [x] Add `cache:rebuild` action
- [x] Update upgrade workflow docs
