### PR TITLE
PF-448: Move script to `tmp` during exec to allow modification

### DIFF
--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -152,8 +152,11 @@ upgrade: ## Upgrade Drupal site
 		echo -e " $(MSG_ERROR) Missing upgrade operations JSON_INPUT."
 		exit 1
 	fi
-	RSH="ddev"
-	bash ./.github/actions/upgrade/upgrade.sh
+	UPGRADE_SCRIPT="./.github/actions/upgrade/upgrade.sh"
+	TEMP_SCRIPT=$$(mktemp)
+	trap "rm -f $$TEMP_SCRIPT" EXIT
+	cp "$$UPGRADE_SCRIPT" "$$TEMP_SCRIPT"
+	RSH="ddev" bash "$$TEMP_SCRIPT"
 
 ## Utility
 launch: ## Launch project


### PR DESCRIPTION
## Issue

During an upgrade workflow run, the `upgrade.sh` can modify itself, something bash really doesn't like. Therefore the script should be moved to `/tmp` and then execute from there. This should make sure it is not modified during execution.

## Tasks

- [x] Move script to `tmp` during exec to allow modification