### PR TITLE
PF-525: Add more matchers to upgrade script

### DIFF
--- a/assets/replace/.github/actions/upgrade/upgrade.sh
+++ b/assets/replace/.github/actions/upgrade/upgrade.sh
@@ -71,9 +71,33 @@ function rsh {
 }
 
 # Check if the the string is a key in the composer requirements.
-function match_exists {
+function package_required {
   MATCH_VALUE=$1
   RESULT=$(jq -r ".require + .[\"require-dev\"] | select(.\"${MATCH_VALUE}\")" "${COMPOSER_JSON_FILE}")
+  [ -n "${RESULT}" ]
+}
+
+# Check if the string is an installed package (composer.lock).
+function package_installed {
+  PACKAGE_VALUE=$1
+  RESULT=$(jq -r ".packages[] | select(.name==\"${PACKAGE_VALUE}\")" "${COMPOSER_JSON_FILE/.json/.lock}")
+  [ -n "${RESULT}" ]
+}
+
+# Check if the the string is a key in the composer requirements.
+function name_matches {
+  NAME_VALUE=$1
+  RESULT=$(jq -r "select(.name==\"${NAME_VALUE}\") | .name" "${COMPOSER_JSON_FILE}")
+  [ -n "${RESULT}" ]
+}
+
+# Check if the the string is an installed drupal extension.
+function drupal_extension_installed {
+  EXTENSION_VALUE=$1
+  CORE_EXTENSION_FILE="$(find "${APP_ROOT}/" -maxdepth 8 -type f -name "core.extension.yml"| head -n 1)"
+  if [ -n "${CORE_EXTENSION_FILE}" ]; then
+    RESULT=$(grep -E "^\s*${EXTENSION_VALUE}:" "${CORE_EXTENSION_FILE}")
+  fi
   [ -n "${RESULT}" ]
 }
 
@@ -85,20 +109,62 @@ for operation in "${OPERATIONS[@]}"; do
   ACTION=$(echo "${operation}" | jq -r '.action')
   MATCH=$(echo "${operation}" | jq -r '.match // ""')
   MATCH_INVERSE=$(echo "${operation}" | jq -r '.matchInverse // ""')
+  MATCH_LOCK=$(echo "${operation}" | jq -r '.matchLock // ""')
+  MATCH_LOCK_INVERSE=$(echo "${operation}" | jq -r '.matchLockInverse // ""')
+  MATCH_NAME=$(echo "${operation}" | jq -r '.matchName // ""')
+  MATCH_NAME_INVERSE=$(echo "${operation}" | jq -r '.matchNameInverse // ""')
+  MATCH_EXTENSION=$(echo "${operation}" | jq -r '.matchExtension // ""')
+  MATCH_EXTENSION_INVERSE=$(echo "${operation}" | jq -r '.matchExtensionInverse // ""')
 
   echo -e "---------------------------------------------------"
   echo -e "\tRunning action: ${ACTION}"
   echo -e "---------------------------------------------------"
 
   # Check if operation matches composer requirements.
-  if [ -n "${MATCH}" ] && ! match_exists "${MATCH}"; then
-    echo "Didn't match \"${MATCH}\". Skipping operation."
+  if [ -n "${MATCH}" ] && ! package_required "${MATCH}"; then
+    echo "Didn't match \"${MATCH}\" in composer.json. Skipping operation."
     continue
   fi
 
   # Check if operation doesn't match composer requirements.
-  if [ -n "${MATCH_INVERSE}" ] && match_exists "${MATCH_INVERSE}"; then
-    echo "Matched \"${MATCH_INVERSE}\". Skipping operation."
+  if [ -n "${MATCH_INVERSE}" ] && package_required "${MATCH_INVERSE}"; then
+    echo "Matched \"${MATCH_INVERSE}\" in composer.json. Skipping operation."
+    continue
+  fi
+
+  # Check if operation matches composer requirements.
+  if [ -n "${MATCH_LOCK}" ] && ! package_installed "${MATCH_LOCK}"; then
+    echo "Didn't match \"${MATCH_LOCK}\" in composer.lock. Skipping operation."
+    continue
+  fi
+
+  # Check if operation doesn't match composer requirements.
+  if [ -n "${MATCH_LOCK_INVERSE}" ] && package_installed "${MATCH_LOCK_INVERSE}"; then
+    echo "Matched \"${MATCH_LOCK_INVERSE}\" in composer.lock. Skipping operation."
+    continue
+  fi
+
+  # Check if operation matches composer project name.
+  if [ -n "${MATCH_NAME}" ] && ! name_matches "${MATCH_NAME}"; then
+    echo "Didn't match \"${MATCH_NAME}\" name in composer.json. Skipping operation."
+    continue
+  fi
+
+  # Check if operation doesn't match composer project name.
+  if [ -n "${MATCH_NAME_INVERSE}" ] && name_matches "${MATCH_NAME_INVERSE}"; then
+    echo "Matched \"${MATCH_NAME_INVERSE}\" name in composer.json. Skipping operation."
+    continue
+  fi
+
+  # Check if operation matches installed drupal extensions.
+  if [ -n "${MATCH_EXTENSION}" ] && ! drupal_extension_installed "${MATCH_EXTENSION}"; then
+    echo "Didn't match \"${MATCH_EXTENSION}\" in core.extension.yml. Skipping operation."
+    continue
+  fi
+
+  # Check if operation doesn't match installed drupal extensions.
+  if [ -n "${MATCH_EXTENSION_INVERSE}" ] && drupal_extension_installed "${MATCH_EXTENSION_INVERSE}"; then
+    echo "Matched \"${MATCH_EXTENSION_INVERSE}\" in core.extension.yml. Skipping operation."
     continue
   fi
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -69,12 +69,18 @@ A JSON payload has to follow this structure:
 
 * `operations`: Operations Array (`array`)
    * Operation object
-      * `match`: (optional) Matching a requirement (key) in the `require` or `require-dev` of the `composer.json` (`string`)
-      * `matchInverse`: (optional) Inverse matching a requirement (key) in the `require` or `require-dev` of the `composer.json` (`string`)
       * `action`: The desired action (e.g. `require`) (`string`)
       * `data`: (optional) The data for the action (e.g. `dompdf/dompdf`) (`string`|`array`)
       * `options`: (optional) Options for the action (e.g. `--dev`) (`string`)
       * `key`: (required for `config` and `config:set` actions) The configuration key to set (e.g. `platform.php`) (`string`)
+      * `match`: (optional) Matching a requirement (key) in the `require` or `require-dev` of the `composer.json` (`string`)
+      * `matchInverse`: (optional) Inverse matching a requirement (key) in the `require` or `require-dev` of the `composer.json` (`string`)
+      * `matchLock`: (optional) Matching a installed package in the `composer.lock` (`string`)
+      * `matchLockInverse`: (optional) Inverse matching a installed package in the `composer.lock` (`string`)
+      * `matchName`: (optional) Matching the `name` (key) in the `composer.json` (`string`)
+      * `matchNameInverse`: (optional) Inverse matching the `name` (key) in the `composer.json` (`string`)
+      * `matchExtension`: (optional) Matching the name of a module or theme in the `core.extension.yml` of the Drupal config (`string`)
+      * `matchExtensionInverse`: (optional) Inverse matching the name of a module or theme in the `core.extension.yml` of the Drupal config (`string`)
 
 An example operation for removing `dompdf/dompdf` if it is installed and requiring `iqual/iq_barrio` and `drupal/antibot:^2.0` and updating all depedencies would look like this:
 


### PR DESCRIPTION
## Feature

Currently the upgrade script can only check the required (including dev) packages in the `composer.json` as a condition for running an action. This should be extended to support installed packages in the lock, the name of the project and Drupal extensions.

## Tasks

- [x] Add more matchers to upgrade script
- [x] Update documentation

## Comments

* The `core.extension.yml` discovery is rather naive using `find`. This could be improved on.
* The available matchers are:
  * `match`: Matching a requirement (key) in the `require` or `require-dev` of the `composer.json` (`string`)
  * `matchInverse`: Inverse matching a requirement (key) in the `require` or `require-dev` of the `composer.json` (`string`)
  * `matchLock`: Matching a installed package in the `composer.lock` (`string`)
  * `matchLockInverse`: Inverse matching a installed package in the `composer.lock` (`string`)
  * `matchName`: Matching the `name` (key) in the `composer.json` (`string`)
  * `matchNameInverse`: Inverse matching the `name` (key) in the `composer.json` (`string`)
  * `matchExtension`: Matching the name of a module or theme in the `core.extension.yml` of the Drupal config (`string`)
  * `matchExtensionInverse`: Inverse matching the name of a module or theme in the `core.extension.yml` of the Drupal config (`string`)