### PR TITLE
PF-448: Rename upgrade script for easier migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ assets/replace/
 │   │   │   └── action.yml.twig
 │   │   └── upgrade
 │   │       ├── rector.php
-│   │       └── upgrade.sh
+│   │       └── upgrader.sh
 │   └── workflows
 │       ├── phpcs.yml.twig
 │       ├── phpunit-functional-testing.yml.twig

--- a/assets/replace/.github/actions/upgrade/upgrader.sh
+++ b/assets/replace/.github/actions/upgrade/upgrader.sh
@@ -6,10 +6,10 @@
 # Also requires a JSON_INPUT as either env var, stdin or file
 #
 # Usage:
-#       ./upgrade.sh operation.json
+#       ./upgrader.sh operation.json
 # Alt:
-#       cat operations.json | ./upgrade.sh
-#       echo '{"operations":[{"action":"config:export"}]}' | ./upgrade.sh
+#       cat operations.json | ./upgrader.sh
+#       echo '{"operations":[{"action":"config:export"}]}' | ./upgrader.sh
 
 set -eo pipefail
 
@@ -30,8 +30,8 @@ fi
 
 if [[ -z "$JSON_INPUT" ]]; then
   echo "No input given!"
-  echo "Usage: ./upgrade.sh operation.json"
-  echo "Or by piping: cat operations.json | ./upgrade.sh"
+  echo "Usage: ./upgrader.sh operation.json"
+  echo "Or by piping: cat operations.json | ./upgrader.sh"
   exit 1
 fi
 

--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -152,7 +152,7 @@ upgrade: ## Upgrade Drupal site
 		echo -e " $(MSG_ERROR) Missing upgrade operations JSON_INPUT."
 		exit 1
 	fi
-	UPGRADE_SCRIPT="./.github/actions/upgrade/upgrade.sh"
+	UPGRADE_SCRIPT="./.github/actions/upgrade/upgrader.sh"
 	TEMP_SCRIPT=$$(mktemp)
 	trap "rm -f $$TEMP_SCRIPT" EXIT
 	cp "$$UPGRADE_SCRIPT" "$$TEMP_SCRIPT"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -25,7 +25,7 @@ The following `make` targets are available in the project's `Makefile`. They can
     * Execute `make db-sync` and `make fs-sync` if the database is empty
     * Runs `drush deploy` (WARNING: This will override config)
 * `update`: Update the Drupal site (`composer` and `drush`) and export the new config
-* `upgrade`: Upgrade the Drupal site by running the `upgrade.sh` script with a `JSON_INPUT`. See the [upgrade workflow documentation](automation.md#upgrade-drupal-project).
+* `upgrade`: Upgrade the Drupal site by running the `upgrader.sh` script with a `JSON_INPUT`. See the [upgrade workflow documentation](automation.md#upgrade-drupal-project).
 * `theme`: Compile the current Drupal theme (`iq_barrio`)
 * `db-backup`: Alias for db-dump wth `$APP_ROOT/backups` as backup folder
 * `db-dump`: Dump the Drupal database to `$DUMP_FOLDER` (or if not set to `$APP_ROOT`)

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -80,8 +80,8 @@ The `.github` directory contains the GitHub Actions workflows for continous inte
 │   ├── install-local
 │   │   └── action.yml                 # Composite action for installing Drupal
 │   └── upgrade
-│       ├── rector.php                 # Default/fallback rector config for upgrade.sh
-│       └── upgrade.sh                 # Composite action for installing Drupal
+│       ├── rector.php                 # Default/fallback rector config for upgrader.sh
+│       └── upgrader.sh                 # Composite action for installing Drupal
 ├── workflows
 │   ├── phpcs.yml                      # Automated PHPCS Linting
 │   ├── phpunit-functional-testing.yml # Automated PHPUnit Functional Testing


### PR DESCRIPTION
## Issue

Since an upgrade to the `2.x` version of the `drupal-platform` would modify the `upgrade.sh` it could break the workflow. To make this migration easier, the upgrade script is renamed to `upgrader.sh`, so it won't modify the legay `upgrade.sh` file.

- [x] Rename upgrade script from `upgrade.sh` to `upgrader.sh`

## Comments

* This will leave a legacy  `upgrade.sh` file in the repo that is being migrated which will need later clean-up.