### PR TITLE
PF-465: Add config pull workflow

### DIFF
--- a/assets/replace/.github/workflows/config-pull.yml.twig
+++ b/assets/replace/.github/workflows/config-pull.yml.twig
@@ -1,0 +1,73 @@
+name: Pull remote config
+
+env:
+  PHP_VERSION: "{{ runtime.php_version }}"
+
+{% verbatim -%}
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        required: false
+        type: string
+        description: 'Config pull source (Default: SPOT)'
+  workflow_call:
+
+concurrency:
+  group: ci-drupal-pull-config-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  config-pull:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+      with:
+        token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+
+    - name: "Set up PHP"
+      uses: shivammathur/setup-php@v2
+      with:
+        extensions: "gd, imagick, bcmath"
+        php-version: "${{ env.PHP_VERSION }}"
+
+    - name: "Prepare environment"
+      shell: bash
+      run: |
+        echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+
+    - name: "Install dependencies"
+      shell: bash
+      run: |
+        composer install --ansi --no-interaction --no-progress --working-dir="./app"
+        echo "${{ github.workspace }}/app/vendor/bin" >> $GITHUB_PATH
+
+    - name: "Setup SSH key"
+      shell: bash
+      run: |
+        mkdir -p /home/runner/.ssh
+        echo "${{ inputs.ssh_key }}" > /home/runner/.ssh/id_rsa
+        chmod 700 /home/runner/.ssh
+        chmod 600 /home/runner/.ssh/id_rsa
+
+    - name: Pull config from ${{ github.event.inputs.environment || 'SPOT' }}
+      shell: bash
+      run: |
+        if [[ -n '${{ github.event.inputs.environment }}' ]]; then
+          echo "Validating environment input variable."
+          [[ '${{ github.event.inputs.environment }}' =~ ^[a-z0-9\-]{3,25}$ ]] || exit 1
+          drush config:pull "@${{ github.event.inputs.environment }}" @self
+        else
+          drush config:pull @spot @self
+        fi
+        rm /home/runner/.ssh/id_rsa
+
+    - name: Commit config changes
+      uses: stefanzweifel/git-auto-commit-action@v7
+      with:
+        commit_message: "Synced config from ${{ github.event.inputs.environment || 'SPOT' }}"
+{% endverbatim -%}

--- a/assets/replace/.github/workflows/config-pull.yml.twig
+++ b/assets/replace/.github/workflows/config-pull.yml.twig
@@ -49,10 +49,16 @@ jobs:
     - name: "Setup SSH key"
       shell: bash
       run: |
-        mkdir -p /home/runner/.ssh
-        echo "${{ inputs.ssh_key }}" > /home/runner/.ssh/id_rsa
-        chmod 700 /home/runner/.ssh
-        chmod 600 /home/runner/.ssh/id_rsa
+        mkdir -p "$HOME/.ssh"
+        echo "${{ secrets.SSH_KEY }}" > "$HOME/.ssh/id_rsa"
+        chmod 700 "$HOME/.ssh"
+        chmod 600 "$HOME/.ssh/id_rsa"
+
+        eval "$(ssh-agent -s)"
+        ssh-add "$HOME/.ssh/id_rsa"
+
+        echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
+        echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> "$GITHUB_ENV"
 
     - name: Pull config from ${{ github.event.inputs.environment || 'SPOT' }}
       shell: bash
@@ -64,7 +70,7 @@ jobs:
         else
           drush config:pull @spot @self
         fi
-        rm /home/runner/.ssh/id_rsa
+        rm "$HOME/.ssh/id_rsa"
 
     - name: Commit config changes
       uses: stefanzweifel/git-auto-commit-action@v7

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -4,6 +4,7 @@ There are multiple GitHub Action workflows for running common automation tasks.
 
 * [Update: Updating Drupal projects](#update-drupal-project)
 * [Upgrade: Upgrading Drupal projects with specific operations](#upgrade-drupal-project)
+* [Config: Pull remote config](#config-pull)
 * [Testing: Test the Drupal project](#testing)
    * [PHPCS: Linting](#phpcs)
    * [PHPUnit: Unit Testing](#phpunit-unit-testing)
@@ -198,6 +199,21 @@ An example operation for removing `dompdf/dompdf` if it is installed and requiri
 </details>
 
 > In the GitHub web UI you have to make sure to escape double-quotes (e.g. `{\"operations\": [{\"action\": \"config:export\"}]}`).
+
+## Config Pull
+
+Pulls the remote environments' Drupal configuration without fully deploying a environment locally. This works by running a `drush config:pull` and commiting directly to the branch that the workflow was triggered on.
+
+* Workflow: `config-pull.yml`
+* Runs on:
+   * Manual dispatch
+   * Call from other workflow
+
+* Inputs
+  * Environment: Config pull source (Default: SPOT)
+
+> [!WARNING]
+> This workflow will lead to deployments since it pulls configuration from the specified source of truth and commit it to the selected branch (e.g. `main` and thus production).
 
 ## Testing
 


### PR DESCRIPTION
## Feature

This pull request introduces a new GitHub Actions workflow for pulling remote Drupal configuration and updates the documentation to describe its usage. The main focus is on automating the process of syncing configuration from a remote environment and committing it to the repository.

## Tasks

- [x] Add config pull workflow that doesn't need a full deployment
- [x] Add documentation
