### PR TITLE
PF-464: Add identifiers and labels to update workflows

### DIFF
--- a/assets/replace/.github/actions/install-local/action.yml.twig
+++ b/assets/replace/.github/actions/install-local/action.yml.twig
@@ -56,6 +56,8 @@ runs:
 
   - name: Setup DDEV
     uses: ddev/github-action-setup-ddev@v1
+    with:
+      version: ${{ env.DDEV_VERSION || 'latest' }}
 
   - name: Deploy local environment
     shell: bash

--- a/assets/replace/.github/workflows/update.yml.twig
+++ b/assets/replace/.github/workflows/update.yml.twig
@@ -3,7 +3,7 @@
 name: Update Drupal Project
 
 env:
-  DOCKER_WEB_PORT: 80:80
+  DDEV_VERSION: ${{ vars.DDEV_VERSION || 'latest' }}
 
 on:
   workflow_dispatch:
@@ -11,8 +11,19 @@ on:
       token:
         required: false
         type: string
-        description: 'If you want pull requests created by this action to trigger an on: push or on: pull_request workflow then you cannot use the default GITHUB_TOKEN and need a Personal Access Token. If you want to use the GITHUB_TOKEN, then leave this field blank.'
-
+        description: 'Personal Access Token for code write permissions and pull requests created by this workflow to trigger other workflows.'
+      labels:
+        required: false
+        type: string
+        description: "Comma-separated list of labels to apply to the pull request."
+      id:
+        required: false
+        type: string
+        description: "Optional identifier (e.g. Jira ID) to distinguish this workflow run in the commit message and pull request title (default: timestamp)."
+      branch:
+        required: false
+        type: string
+        description: "Optional branch name for the pull request (default: misc/update-<timestamp>)."
 jobs:
   update:
     runs-on: ubuntu-latest
@@ -35,11 +46,12 @@ jobs:
         fi
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@v8
+      if: ${{ github.event.inputs.branch != 'main' }}
       with:
         token: ${{ github.event.inputs.token || secrets.GITHUB_TOKEN }}
-        commit-message: Updated Drupal site
-        title: Update Drupal site (${{ env.EXECUTION_DATE }})
+        commit-message: "${{ github.event.inputs.id && format('{0}: Updated Drupal site', github.event.inputs.id) || 'Updated Drupal site' }}"
+        title: "${{ github.event.inputs.id && format('{0}: Update Drupal site', github.event.inputs.id) || format('Update Drupal site ({0})', env.EXECUTION_DATE) }}"
         body: |
           Automatically generated Drupal update (${{ env.EXECUTION_DATE }}):
 
@@ -53,6 +65,6 @@ jobs:
           - [ ] Deploy update to live website
 
           Check the logs in the [Github Actions workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more information about the update.
-        branch: misc/update-${{ env.EXECUTION_DATE }}
+        branch: "${{ github.event.inputs.branch || format('misc/update-{0}', env.EXECUTION_DATE) }}"
 {% endverbatim -%}
 {% endif %}

--- a/assets/replace/.github/workflows/upgrade.yml.twig
+++ b/assets/replace/.github/workflows/upgrade.yml.twig
@@ -3,7 +3,7 @@
 name: Upgrade Drupal Project
 
 env:
-  DOCKER_WEB_PORT: 80:80
+  DDEV_VERSION: ${{ vars.DDEV_VERSION || 'latest' }}
 
 on:
   workflow_dispatch:
@@ -11,7 +11,7 @@ on:
       token:
         required: false
         type: string
-        description: 'If you want pull requests created by this action to trigger an on: push or on: pull_request workflow then you cannot use the default GITHUB_TOKEN and need a Personal Access Token. If you want to use the GITHUB_TOKEN, then leave this field blank.'
+        description: 'Personal Access Token for code write permissions and pull requests created by this workflow to trigger other workflows.'
       require:
         required: false
         type: string
@@ -32,6 +32,18 @@ on:
         required: false
         type: string
         description: "JSON encoded operation payload for advanced usage. See documentation."
+      labels:
+        required: false
+        type: string
+        description: "Comma-separated list of labels to apply to the pull request."
+      id:
+        required: false
+        type: string
+        description: "Optional identifier (e.g. Jira ID) to distinguish this workflow run in the commit message and pull request title (default: timestamp)."
+      branch:
+        required: false
+        type: string
+        description: "Optional branch name for the pull request (default: misc/upgrade-<timestamp>)."
 
 jobs:
   upgrade:
@@ -104,11 +116,13 @@ jobs:
         fi
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@v8
+      if: ${{ github.event.inputs.branch != 'main' }}
       with:
         token: ${{ github.event.inputs.token || secrets.GITHUB_TOKEN }}
-        commit-message: Upgraded Drupal site
-        title: Upgraded Drupal site (${{ env.EXECUTION_DATE }})
+        commit-message: "${{ github.event.inputs.id && format('{0}: Upgraded Drupal site', github.event.inputs.id) || 'Upgraded Drupal site' }}"
+        title: "${{ github.event.inputs.id && format('{0}: Upgraded Drupal site', github.event.inputs.id) || format('Upgraded Drupal site ({0})', env.EXECUTION_DATE) }}"
+        labels: ${{ github.event.inputs.labels }}
         body: |
           Automatically generated Drupal upgrade (${{ env.EXECUTION_DATE }}):
 
@@ -128,6 +142,6 @@ jobs:
           </details>
 
           Check the logs in the [Github Actions workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more information about the upgrade.
-        branch: misc/upgrade-${{ env.EXECUTION_DATE }}
+        branch: "${{ github.event.inputs.branch || format('misc/upgrade-{0}', env.EXECUTION_DATE) }}"
 {% endverbatim -%}
 {% endif %}

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -20,6 +20,9 @@ There are multiple GitHub Action workflows for running common automation tasks.
 
 * Inputs
    * Token: GitHub Personal Access Token
+   * Labels: Comma-separated list of labels to apply to the pull request
+   * ID: Optional identifier (e.g. Jira ID) to distinguish this workflow run in the commit message and pull request title (default: timestamp)
+   * Branch: Optional branch name for the pull request (default: `misc/update-<timestamp>`).
 
 This workflow will install the project in a GitHub Actions runner environment and run the Drupal update process on it (`make update`). If successful it will create a pull request with the changes. If a token is provided then the pull request created by this workflow will trigger other workflows running on push or pull request triggers.
 
@@ -37,6 +40,9 @@ This workflow will install the project in a GitHub Actions runner environment an
    * Enable: Enable a module or list of modules with Drush
    * Uninstall: Uninstall a module or list of modules with Drush
    * Payload: JSON encoded operation payload for advanced usage
+   * Labels: Comma-separated list of labels to apply to the pull request
+   * ID: Optional identifier (e.g. Jira ID) to distinguish this workflow run in the commit message and pull request title (default: timestamp)
+   * Branch: Optional branch name for the pull request (default: `misc/upgrade-<timestamp>`).
 
 This workflow will install the project in a GitHub Actions runner environment and run the Drupal upgrade process on it (`make upgrade`) using either the provided `require`, `remove`, `enable` and `uninstall` inputs or the provided `payload` (`payload` always overrides other inputs). If successful it will create a pull request with the changes. If a token is provided then the pull request created by this workflow will trigger other workflows running on push or pull request triggers.
 


### PR DESCRIPTION
## Issue

To streamline the automated execution of Drupal project updates the ability to add a custom identifier (e.g. Jira isse number) in the pull request title, to add labels and customize the update/upgrade's branch name would be helpful.

## Tasks

- [x] Add ID input to update/upgrade workflow PR title
- [x] Add label input to update/upgrade workflow PR
- [x] Add branch input to update/upgrade workflow PR
- [x] Upgrade `peter-evans/create-pull-request` to `v8`
- [x] Update docs on new inputs
- [x] Add support for `DDEV_VERSION` on update/upgrade