### PR TITLE
PF-467: Add `ready_for_review` trigger on PR for VRT

### DIFF
--- a/assets/replace/.github/workflows/phpunit-functional-testing.yml.twig
+++ b/assets/replace/.github/workflows/phpunit-functional-testing.yml.twig
@@ -2,6 +2,9 @@
 name: PHPUnit functional testing
 
 {% verbatim -%}
+env:
+  DDEV_VERSION: ${{ vars.DDEV_VERSION || 'latest' }}
+
 on:
   workflow_dispatch:
     inputs:

--- a/assets/replace/.github/workflows/testing.yml.twig
+++ b/assets/replace/.github/workflows/testing.yml.twig
@@ -2,6 +2,9 @@
 {%- verbatim -%}
 name: Drupal testing
 
+env:
+  DDEV_VERSION: ${{ vars.DDEV_VERSION || 'latest' }}
+
 on:
   workflow_dispatch:
   pull_request:

--- a/assets/replace/.github/workflows/visual-regression-testing.yml.twig
+++ b/assets/replace/.github/workflows/visual-regression-testing.yml.twig
@@ -60,7 +60,7 @@ jobs:
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, ready_for_review]
 
 jobs:
   run-vr-tests:

--- a/assets/replace/.github/workflows/visual-regression-testing.yml.twig
+++ b/assets/replace/.github/workflows/visual-regression-testing.yml.twig
@@ -3,6 +3,9 @@ name: Visual Regression testing
 
 {% if workflows.phpunit %}
 {% verbatim -%}
+env:
+  DDEV_VERSION: ${{ vars.DDEV_VERSION || 'latest' }}
+
 on:
   workflow_dispatch:
   workflow_call:
@@ -57,6 +60,9 @@ jobs:
 {% endverbatim -%}
 {% else %}
 {% verbatim -%}
+env:
+  DDEV_VERSION: ${{ vars.DDEV_VERSION || 'latest' }}
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
## Issue

Currently the VRT workflows will only run when `opening` or `reopening` pull requests. Instead of forcing developers to re-open PRs, add the `ready_for_review` trigger so it is possible to put PRs into draft and then set them to ready for review.

## Tasks

- [x] Add `ready_for_review` trigger on `pull_request` in `visual-regression-testing.yml`
- [x] Add support for `DDEV_VERSION` on testing workflows