### PR TITLE
PF-512: Add git ignore for supporting secrets to `.ddev/.env`

### DIFF
--- a/assets/merge/.gitignore.twig
+++ b/assets/merge/.gitignore.twig
@@ -97,6 +97,7 @@ maintenance_*.html
 # Ignore DDEV Secrets and CI config
 .ddev/homeadditions/.ssh
 .ddev/config.ci.yaml
+.ddev/.env
 
 # Ignore some DDEV add-on folders
 .ddev/addon-metadata/*chrome/manifest.yaml


### PR DESCRIPTION
## Issue

Currently it's not possible to add secrets to the DDEV support. To re-add that feature, we'd like to use the `.ddev/.env` file, which is by default version controlled. In order to not commit any sensitive values, this should be git ignored.

## Tasks

- [x] Add git ignore for supporting secrets to `.ddev/.env`

## Comments

* [Documentation on DDEV env variables](https://docs.ddev.com/en/stable/users/extend/customization-extendibility/#environment-variables-for-containers-and-services)
