### PR TITLE
PF-512: Fix sql dump directory for new install

### DIFF
--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -104,8 +104,8 @@ drupal-db: ## Import drupal database
 	@echo -e " $(MSG_INFO) Importing Drupal database"
 	if [ "$(NEW_PROJECT)" = "true" ]; then
 		echo -e " $(MSG_INFO) Running Drupal site install"
-		if compgen -G "$$DDEV_COMPOSER_ROOT/resources/*.sql.gz" > /dev/null; then
-			ddev drush sqlq --file=$$(compgen -G "$$DDEV_COMPOSER_ROOT/resources/*.sql.gz" | head -1)
+		if compgen -G "./app/resources/*.sql.gz" > /dev/null; then
+			ddev drush sqlq --file=$$(compgen -G "./app/resources/*.sql.gz" | head -1)
 			ddev drush updb
 		else
 			ddev drush si --existing-config --yes $(DRUSH_FLAGS)


### PR DESCRIPTION
## Issue

Currently a new installation fails when running `make new` with a SQL dump in the `./app/resources` folder, since `make new` is run from the host, and `$DDEV_COMPOSER_ROOT` is only set in the runtime.

## Tasks

- [x] Fix sql dump directory for new install