### PR TITLE
PF-512: Fix `drush sqlq` ddev project root

### DIFF
--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -105,7 +105,7 @@ drupal-db: ## Import drupal database
 	if [ "$(NEW_PROJECT)" = "true" ]; then
 		echo -e " $(MSG_INFO) Running Drupal site install"
 		if compgen -G "./app/resources/*.sql.gz" > /dev/null; then
-			ddev drush sqlq --file=$$(compgen -G "./app/resources/*.sql.gz" | head -1)
+			ddev drush sqlq --file=/var/www/html/$$(compgen -G "./app/resources/*.sql.gz" | head -1)
 			ddev drush updb
 		else
 			ddev drush si --existing-config --yes $(DRUSH_FLAGS)


### PR DESCRIPTION
## Issue

Follow up to #66.

Currently a new installation fails when running `make new` with a SQL dump in the `./app/resources` folder, since `ddev drush` runs from a different file root than on the host. Therefore the file path should be absolute for DDEV.

## Tasks

- [x] Fix `drush sqlq` ddev project root