### PR TITLE
PF-512: Disable `drush deploy` step for new projects

### DIFF
--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -72,7 +72,7 @@ install: runtime stack ## Install project stack with runtime
 
 new: ## Create new project
 	@echo -e " $(MSG_INFO) Creating new project"
-	$(MAKE) install NEW_PROJECT=true
+	$(MAKE) install NEW_PROJECT=true DRUPAL_NO_DEPLOY=true
 
 runtime: ## Start local runtime
 	@echo -e " $(MSG_INFO) Starting DDEV runtimes"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -23,7 +23,7 @@ The project includes a `Makefile` with predefined targets for common project tas
         * `drupal-deploy`: Run Drupal deployment commands (`drush deploy`, skipped if `DRUPAL_NO_DEPLOY=true`)
 
 * `install-safe`: Same as `install` but first checks for uncommitted git changes
-* `new`: Create a new Drupal project (runs `install` with `NEW_PROJECT=true`, which runs `drush site:install` or imports a database backup from `app/resources`)
+* `new`: Create a new Drupal project (runs `install` with `NEW_PROJECT=true` and `DRUPAL_NO_DEPLOY=true`, which runs `drush site:install` or imports a database backup from `app/resources`)
 
 > [!TIP]
 > Use `DDEV_SNAPSHOT=latest` to restore the latest DDEV snapshot during `make runtime` (or `make install`), or specify a named snapshot with `DDEV_SNAPSHOT=<name>`.


### PR DESCRIPTION
## Issue

Currently when running `make new` it will also run `drush deploy` even when there is no config in the directory yet. This should be disabled since the config has to be exported first. This is a regression to `1.x`.

## Tasks

- [x] Disable `drush deploy` step for `make new`