### PR TITLE
PF-512: Make `make new` non interactive by default

### DIFF
--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -143,7 +143,7 @@ drupal-update:
 	@echo -e " $(MSG_INFO) Updating Drupal"
 	ddev composer update $(COMPOSER_FLAGS)
 	ddev drush cr
-	ddev drush updb $(ddev DRUSH_FLAGS)
+	ddev drush updb $(DRUSH_FLAGS)
 	ddev drush cex $(DRUSH_FLAGS)
 
 upgrade: ## Upgrade Drupal site

--- a/assets/replace/Makefile
+++ b/assets/replace/Makefile
@@ -106,7 +106,7 @@ drupal-db: ## Import drupal database
 		echo -e " $(MSG_INFO) Running Drupal site install"
 		if compgen -G "./app/resources/*.sql.gz" > /dev/null; then
 			ddev drush sqlq --file=/var/www/html/$$(compgen -G "./app/resources/*.sql.gz" | head -1)
-			ddev drush updb
+			ddev drush updb --yes $(DRUSH_FLAGS)
 		else
 			ddev drush si --existing-config --yes $(DRUSH_FLAGS)
 		fi


### PR DESCRIPTION
## Issue

Currently the `make new` command will prompt if there is a requirement check reporting any warning or error by `drush updb`. This should be non interactive by default.

## Tasks

- [x] Make `make new` non interactive by default
- [x] Add `DRUSH_FLAGS` to `updb` in `make new`