### PR TITLE
PF-512: Fix backwards compatibility for escaping quotes in upgrade script

### DIFF
--- a/assets/replace/.github/actions/upgrade/upgrader.sh
+++ b/assets/replace/.github/actions/upgrade/upgrader.sh
@@ -58,8 +58,22 @@ if [[ -n "$RSH" && "$RSH" == "ddev" ]]; then
   echo "Using remote shell: ddev"
 fi
 
+# Pretty print the command to be run, with proper quoting for arguments with spaces.
+function log_cmd {
+  local parts=()
+  for arg in "$@"; do
+    if [[ "$arg" =~ [[:space:]] ]]; then
+      parts+=("\"$arg\"")
+    else
+      parts+=("$arg")
+    fi
+  done
+  echo "${parts[*]}"
+}
+
+# Run command locally or in environment.
 function rsh {
-  echo "$@"
+  log_cmd "$@"
   if [[ -n "$RSH" && "$RSH" == "make-cli" ]]; then
     # Make sure the arguments' value is quoted in a format that can be reused as input.
     COMMAND="${*@Q}" make cli
@@ -130,9 +144,13 @@ for operation in "${OPERATIONS[@]}"; do
   MATCH_EXTENSION=$(echo "${operation}" | jq -r '.matchExtension // ""')
   MATCH_EXTENSION_INVERSE=$(echo "${operation}" | jq -r '.matchExtensionInverse // ""')
 
-  echo -e "---------------------------------------------------"
-  echo -e "\tRunning action: ${ACTION}"
-  echo -e "---------------------------------------------------"
+  if [[ -n "$GITHUB_ACTIONS" ]]; then
+    echo "::group::${ACTION}"
+  else
+    echo -e "---------------------------------------------------"
+    echo -e "\tRunning action: ${ACTION}"
+    echo -e "---------------------------------------------------"
+  fi
 
   # Check if operation matches composer requirements.
   if [ -n "${MATCH}" ] && ! package_required "${MATCH}"; then
@@ -368,6 +386,10 @@ for operation in "${OPERATIONS[@]}"; do
       echo "Unsupported action: ${ACTION}"
       ;;
   esac
+
+  if [[ -n "$GITHUB_ACTIONS" ]]; then
+    echo "::endgroup::"
+  fi
 
 done
 

--- a/assets/replace/.github/actions/upgrade/upgrader.sh
+++ b/assets/replace/.github/actions/upgrade/upgrader.sh
@@ -204,6 +204,13 @@ for operation in "${OPERATIONS[@]}"; do
     DATA_ARRAY=()
   fi
 
+  # Strip surrounding double quotes from data elements for backwards compatibility.
+  for i in "${!DATA_ARRAY[@]}"; do
+    if [[ "${DATA_ARRAY[$i]}" =~ ^\"(.*)\"$ ]]; then
+      DATA_ARRAY[$i]="${BASH_REMATCH[1]}"
+    fi
+  done
+
   KEY=$(echo "${operation}" | jq -r '.key')
 
   # Switch to relevant action.

--- a/assets/replace/.github/actions/upgrade/upgrader.sh
+++ b/assets/replace/.github/actions/upgrade/upgrader.sh
@@ -144,13 +144,9 @@ for operation in "${OPERATIONS[@]}"; do
   MATCH_EXTENSION=$(echo "${operation}" | jq -r '.matchExtension // ""')
   MATCH_EXTENSION_INVERSE=$(echo "${operation}" | jq -r '.matchExtensionInverse // ""')
 
-  if [[ -n "$GITHUB_ACTIONS" ]]; then
-    echo "::group::${ACTION}"
-  else
-    echo -e "---------------------------------------------------"
-    echo -e "\tRunning action: ${ACTION}"
-    echo -e "---------------------------------------------------"
-  fi
+  echo -e "---------------------------------------------------"
+  echo -e "\tRunning action: ${ACTION}"
+  echo -e "---------------------------------------------------"
 
   # Check if operation matches composer requirements.
   if [ -n "${MATCH}" ] && ! package_required "${MATCH}"; then
@@ -386,10 +382,6 @@ for operation in "${OPERATIONS[@]}"; do
       echo "Unsupported action: ${ACTION}"
       ;;
   esac
-
-  if [[ -n "$GITHUB_ACTIONS" ]]; then
-    echo "::endgroup::"
-  fi
 
 done
 


### PR DESCRIPTION
## Issue

When using existing upgrade payloads that added quotes with escaping (i.e. `\"`) for removing patches it will fail. This breaks backwards compatibility and both approaches should be supported now.

For example, this is a legacy action:

```json
{"operations":[{"match":"drupal/field_group","action":"patch-remove","data":["drupal/field_group","\"Fix translations label\""]}]}
```

However, now only this is supported:

```json
{"operations":[{"match":"drupal/field_group","action":"patch-remove","data":["drupal/field_group","Fix translations label"]}]}
```

## Tasks

- [x] Fix backwards compatibility for escaping quotes in upgrade script
- [x] Improve logging in upgrade script