### PR TITLE
PF-457: Add support for `extra` settings file

### DIFF
--- a/assets/replace/@web-root/sites/default/settings.php
+++ b/assets/replace/@web-root/sites/default/settings.php
@@ -227,3 +227,7 @@ if (getenv('IS_DDEV_PROJECT') == 'true' && is_readable($ddev_settings)) {
     $config['stage_file_proxy.settings']['origin'] = getenv('DRUPAL_SPOT_ORIGIN');
   }
 }
+
+if (file_exists($app_root . '/' . $site_path . '/settings.extra.php')) {
+    include $app_root . '/' . $site_path . '/settings.extra.php';
+}


### PR DESCRIPTION
## Feature

There are some edge cases where an additional "final" settings file is required to override any previous settings that were set by `settings.platformsh.php` or `settings.ddev.php`. An upcoming example use case will be the redis integration that requires a custom serializer.

> [!NOTE]
> Since this should only be used as a last resort settings file for special use cases, we'll leave this undocumented for now.

## Tasks

- [x] Add support for `extra` settings file