### PR TITLE
PF-529: Update GitHub Actions due to node v20 deprecation

### DIFF
--- a/assets/replace/.github/actions/install-local/action.yml.twig
+++ b/assets/replace/.github/actions/install-local/action.yml.twig
@@ -21,7 +21,7 @@ runs:
 
   - name: Cache Composer dependency
     id: cache-composer
-    uses: actions/cache@v4
+    uses: actions/cache@v5
     with:
       path: .composer
       key: ${{ runner.os }}-build-drupal-composer-${{ hashFiles('**/composer.lock') }}
@@ -29,7 +29,7 @@ runs:
   - name: Cache Drupal database
     if: ${{ inputs.caching == 'true' }}
     id: cache-db
-    uses: actions/cache@v4
+    uses: actions/cache@v5
     with:
       path: .ddev/db_snapshots
       key: ${{ runner.os }}-build-drupal-db-${{ inputs.cache_key }}

--- a/assets/replace/.github/workflows/config-pull.yml.twig
+++ b/assets/replace/.github/workflows/config-pull.yml.twig
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 

--- a/assets/replace/.github/workflows/phpcs.yml.twig
+++ b/assets/replace/.github/workflows/phpcs.yml.twig
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: "Set up PHP"
       uses: shivammathur/setup-php@v2

--- a/assets/replace/.github/workflows/phpunit-functional-testing.yml.twig
+++ b/assets/replace/.github/workflows/phpunit-functional-testing.yml.twig
@@ -42,7 +42,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Install Drupal locally
       uses: ./.github/actions/install-local
@@ -67,7 +67,7 @@ jobs:
 
     - name: Upload HTML output
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: phpunit-db-report
         path: ./app/public/sites/simpletest/browser_output
@@ -79,7 +79,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Install Drupal locally
       uses: ./.github/actions/install-local
@@ -109,7 +109,7 @@ jobs:
 
     - name: Upload HTML output
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: phpunit-browser-report
         path: ./app/public/sites/simpletest/browser_output

--- a/assets/replace/.github/workflows/phpunit-unit-testing.yml.twig
+++ b/assets/replace/.github/workflows/phpunit-unit-testing.yml.twig
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: "Set up PHP"
       uses: shivammathur/setup-php@v2

--- a/assets/replace/.github/workflows/testing.yml.twig
+++ b/assets/replace/.github/workflows/testing.yml.twig
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Install Drupal locally
       uses: ./.github/actions/install-local

--- a/assets/replace/.github/workflows/update.yml.twig
+++ b/assets/replace/.github/workflows/update.yml.twig
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Install Drupal locally
       uses: ./.github/actions/install-local

--- a/assets/replace/.github/workflows/upgrade.yml.twig
+++ b/assets/replace/.github/workflows/upgrade.yml.twig
@@ -51,7 +51,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Generate Input
       shell: bash

--- a/assets/replace/.github/workflows/visual-regression-testing.yml.twig
+++ b/assets/replace/.github/workflows/visual-regression-testing.yml.twig
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Install Drupal locally
       uses: ./.github/actions/install-local
@@ -53,7 +53,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Install Drupal locally
       uses: ./.github/actions/install-local


### PR DESCRIPTION
## Issue

[Node 20 on GitHub Action runners is being deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). All actions still relying on outdated node versions need to be upgraded.

## Tasks

- [x] Update GitHub Actions due to node v20 deprecation
- [x] Update Playwright VRT's GitHub Actions