### PR TITLE
DUP-297: Add drush backup cleanup cron

### DIFF
--- a/assets/merge/.platform.app.yaml.twig
+++ b/assets/merge/.platform.app.yaml.twig
@@ -177,7 +177,7 @@ crons:
         cmd: 'cd public ; drush core-cron'
     drush-backup-cleanup:
         spec: '30 23 * * *'
-        cmd: '[ -d /app/drush-backups ] && find /app/drush-backups -type f -mmin +90 -delete'
+        cmd: '[ -d /app/drush-backups ] && find /app/drush-backups -type f -mmin +90 -delete || true'
 
 source:
     root: app
@@ -188,7 +188,7 @@ type: 'php:{{ runtime.php_version }}'
 crons:
     drush-backup-cleanup:
         spec: '30 23 * * *'
-        cmd: '[ -d /app/drush-backups ] && find /app/drush-backups -type f -mmin +90 -delete'
+        cmd: '[ -d /app/drush-backups ] && find /app/drush-backups -type f -mmin +90 -delete || true'
 {% if runtime.php_memory_limit %}
 variables:
     php:

--- a/assets/merge/.platform.app.yaml.twig
+++ b/assets/merge/.platform.app.yaml.twig
@@ -175,6 +175,9 @@ crons:
     drupal:
         spec: '*/19 * * * *'
         cmd: 'cd public ; drush core-cron'
+    drush-backup-cleanup:
+        spec: '30 23 * * *'
+        cmd: '[ -d /app/drush-backups ] && find /app/drush-backups -type f -mmin +90 -delete'
 
 source:
     root: app
@@ -182,6 +185,10 @@ source:
 {% else %}
 name: 'drupal'
 type: 'php:{{ runtime.php_version }}'
+crons:
+    drush-backup-cleanup:
+        spec: '30 23 * * *'
+        cmd: '[ -d /app/drush-backups ] && find /app/drush-backups -type f -mmin +90 -delete'
 {% if runtime.php_memory_limit %}
 variables:
     php:


### PR DESCRIPTION
## Issue

Drush uses `/app/drush-backups` for temporary storage of Drupal database backups (as well as some other ephemeral files). However in some edge cases, like an aborted `drush sqs:sync` it is possible that the file(s) are not cleaned up properly and remain in the folder. We could move the drush backups folder into `/tmp` using the drush config, however the temporary directory's storage limit (8GB on Upsun) differs from the app's and the `/tmp` folder might not be cleaned up quickly.

## Tasks

- [x] Add drush backup cleanup cron to new and existing `.platform.app.yaml` configurations