### PR TITLE
PF-531: Removed local Drupal installation from Copilot setup steps

### DIFF
--- a/assets/replace/.github/actions/install-local/action.yml.twig
+++ b/assets/replace/.github/actions/install-local/action.yml.twig
@@ -1,4 +1,4 @@
-{% if workflows.update or workflows.vrt or workflows.phpunit or ai.copilot %}
+{% if workflows.update or workflows.vrt or workflows.phpunit %}
 {%- verbatim -%}
 name: Install Drupal locally
 description: Checkout, configure, deploy and install a local drupal project

--- a/assets/replace/.github/workflows/copilot-setup-steps.yml.twig
+++ b/assets/replace/.github/workflows/copilot-setup-steps.yml.twig
@@ -1,54 +1,6 @@
 {% if ai.copilot %}
 name: Copilot setup steps
 
-{% if deployment == "platform.sh" %}
-{% verbatim -%}
-env:
-  DDEV_VERSION: ${{ vars.DDEV_VERSION || 'latest' }}
-
-on:
-  workflow_dispatch:
-
-jobs:
-  # Must be named exactly "copilot-setup-steps" to be picked up by Copilot.
-  copilot-setup-steps:
-    runs-on: {% endverbatim %}{{ workflows.runner | default('ubuntu-latest') }}{% verbatim %}
-
-    timeout-minutes: 45
-
-    permissions:
-      contents: read
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-
-    - name: Install agent skills from the iqual-developer plugin
-      uses: iqual-ch/claude-plugins/.github/actions/install-skills@main
-
-    - name: Install Drupal locally
-      uses: ./.github/actions/install-local
-      with:
-        ssh_key: ${{ secrets.SSH_KEY }}
-
-    # The coding agent gets a fully installed local site but must not be able
-    # to reach remote environments: remove the SSH key before handing over.
-    - name: Remove SSH access to remote environments
-      shell: bash
-      run: |
-        rm -f .ddev/homeadditions/.ssh/id_rsa
-        ddev exec 'rm -f ~/.ssh/id_rsa' || true
-        ddev restart
-
-    - name: Verify remote environment access is gone
-      shell: bash
-      run: |
-        if timeout 30 ddev drush @spot status 2>/dev/null; then
-          echo "::error::drush can still reach @spot over SSH after key removal."
-          exit 1
-        fi
-{% endverbatim -%}
-{% else %}
 on:
   workflow_dispatch:
 
@@ -68,5 +20,4 @@ jobs:
 
     - name: Install agent skills from the iqual-developer plugin
       uses: iqual-ch/claude-plugins/.github/actions/install-skills@main
-{% endif %}
 {% endif %}

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -32,13 +32,9 @@ This keeps skills versioned and updated in one place, instead of drifting copies
 
 ## Copilot coding agent environment
 
-The Copilot cloud agent runs `.github/workflows/copilot-setup-steps.yml` before it starts working (the job must be named exactly `copilot-setup-steps`). The scaffolded workflow:
+The Copilot cloud agent runs `.github/workflows/copilot-setup-steps.yml` before it starts working (the job must be named exactly `copilot-setup-steps`). The scaffolded workflow installs the shared agent skills into `.agents/skills/`.
 
-1. Installs the shared agent skills.
-2. Installs the project locally (DDEV runtime + Drupal, using the `SSH_KEY` secret to sync from the SPOT) — `platform.sh` deployments only.
-3. **Removes the SSH key** and verifies the remote environment is unreachable, so the agent has a full local site and toolchain but no access to remote environments.
-
-For `local-only` deployments only the skills are installed.
+The workflow does **not** install the project locally: a local installation would require passing the `SSH_KEY` secret into the agent's environment, giving it access to remote environments.
 
 The workflow respects the `workflows.runner` variable for custom runner labels and can be disabled entirely with `ai.copilot: false`.
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -296,6 +296,6 @@ The VRT configuration can be customized in the `playwright-vrt.config.json` file
    * Manual dispatch
    * Automatically by the GitHub Copilot coding agent before it starts working
 
-This workflow prepares the ephemeral GitHub Actions environment for the [GitHub Copilot coding agent](https://docs.github.com/en/copilot/using-github-copilot/coding-agent). It installs the shared agent skills from [`iqual-ch/claude-plugins`](https://github.com/iqual-ch/claude-plugins) and — for `platform.sh` deployments — a full local Drupal installation. Afterwards the SSH key is removed and verified to be gone, so the agent can build, lint and test the project but cannot reach remote environments.
+This workflow prepares the ephemeral GitHub Actions environment for the [GitHub Copilot coding agent](https://docs.github.com/en/copilot/using-github-copilot/coding-agent). It installs the shared agent skills from [`iqual-ch/claude-plugins`](https://github.com/iqual-ch/claude-plugins). It does not install Drupal locally, since that would require exposing the `SSH_KEY` secret to the coding agent.
 
 See [AI Integration](./ai.md) for the full concept.


### PR DESCRIPTION
## Issue

The Copilot setup workflow introduced in #76 installs Drupal locally via the `install-local` action, which requires the `SSH_KEY` secret. This conceptually cannot work: the secret would have to be exposed to the coding agent's environment, giving it access to remote environments — a security implication we don't want to take. The Drupal installation part is therefore removed again; the workflow now only installs the shared agent skills.

## Tasks

- [x] Remove the local Drupal installation (and SSH key removal/verification steps) from `copilot-setup-steps.yml`
- [x] Drop the deployment-type distinction in the workflow (both variants are now identical)
- [x] Revert `ai.copilot` from the `install-local` scaffold condition (`workflows.phpunit` stays, PHPUnit uses the action)
- [x] Update AI integration and automation docs